### PR TITLE
[Storybook] Fix - Alert colors

### DIFF
--- a/src/components/utils/Colors/Colors.stories.tsx
+++ b/src/components/utils/Colors/Colors.stories.tsx
@@ -93,7 +93,7 @@ const ColorsTemplate = () => {
               <StyledColor color={COLORS.alert[colorKey].background}>
                 {COLORS.alert[colorKey].background}
               </StyledColor>
-              <div>{COLORS.alert[colorKey].background}</div>
+              <div>{colorKey}</div>
             </StyledColorContainer>
           );
         })}


### PR DESCRIPTION
Juste le petit fix dont on avait parlé sur le storybook Colors qui n'affiche pas le nom de la variant