### PR TITLE
fix: cursor pointer on clear searchbar

### DIFF
--- a/src/components/filters/SearchBar/SearchBar.styles.tsx
+++ b/src/components/filters/SearchBar/SearchBar.styles.tsx
@@ -63,6 +63,7 @@ export const StyledSearchBarClearButton = styled.div`
   height: 20px;
   border-radius: 50%;
   justify-content: center;
+  cursor: pointer;
 `;
 
 export const StyledSearchBarSubmitButton = styled.a`


### PR DESCRIPTION
Mini fix, je me suis rendu compte pendant le Sprint Demo que le bouton clear n'avait pas le bon curseur