### PR TITLE
[EN-8372 + EN-8373] Hide empty ProfileDocuments + fix duplicate businessSectors in ProfileCard

### DIFF
--- a/src/components/profile/ProfilePartCards/ProfileDocuments/ProfileDocuments.tsx
+++ b/src/components/profile/ProfilePartCards/ProfileDocuments/ProfileDocuments.tsx
@@ -64,7 +64,8 @@ export const ProfileDocuments = ({
     });
   }, [updateUserProfile]);
 
-  if (!isEditable && !isCompleted) {
+  // In profile view, we don't show the card if there are no linkedInUrl (externalCv is not displayed in profile view)
+  if (!isEditable && !linkedinUrl) {
     return null;
   }
 

--- a/src/components/utils/Cards/ProfileCard/ProfileCard.tsx
+++ b/src/components/utils/Cards/ProfileCard/ProfileCard.tsx
@@ -109,9 +109,10 @@ export function ProfileCard({
   const labels = useMemo(() => getLabelsDependingOnRole(role), [role]);
 
   const sortedBusinessSectors = useMemo(() => {
-    return sectorOccupations
+    const items = sectorOccupations
       ?.filter((so) => !!so.businessSector)
       ?.map((so) => so.businessSector) as BusinessSector[];
+    return _.uniqBy(items, 'id');
   }, [sectorOccupations]);
 
   const sortedOccupations = useMemo(() => {


### PR DESCRIPTION
**🗒️ Ticket Jira :**
[EN-8372](https://entourage-asso.atlassian.net/browse/EN-8372)
[EN-8373](https://entourage-asso.atlassian.net/browse/EN-8373)

**🚧 PR-Back :** N/A

**💬 Commentaire :**

[EN-8372] Aujourd'hui, on cache si on a pas de LinkedInUrl et qu'on a pas de CV externe. Hors, le CV externe n'apparait plus, donc on peut se retrouver avec un bloc vide dans la partie profile.
Donc on conditionne uniquement par rapport à ce critère si on est en mode view only.

[EN-8373] uniqBy id pour éviter les double businessSectors

[EN-8372]: https://entourage-asso.atlassian.net/browse/EN-8372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EN-8373]: https://entourage-asso.atlassian.net/browse/EN-8373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-8373]: https://entourage-asso.atlassian.net/browse/EN-8373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ