### PR TITLE
fix: ajouter un lien simple pour accéder à la réunion en ligne

### DIFF
--- a/src/components/ui/Cards/EntityCards/EventCard/EventCard.tsx
+++ b/src/components/ui/Cards/EntityCards/EventCard/EventCard.tsx
@@ -71,8 +71,6 @@ export function EventCard({
       </StyledEventCardPictureContainer>
       <StyledEventCardContentContainer>
         <H5 title={name} />
-        {/* TODO: Add the targeted roles badges */}
-
         <EventInfoSummary
           startDate={startDate}
           mode={mode}
@@ -80,6 +78,8 @@ export function EventCard({
           fullAddress={fullAddress}
           registrationCount={registrationCount}
           displayParticipants
+          isParticipating={isParticipating}
+          compact
         />
       </StyledEventCardContentContainer>
     </EntityCard>

--- a/src/features/backoffice/events/EventInfoSummary/EventInfoSummary.tsx
+++ b/src/features/backoffice/events/EventInfoSummary/EventInfoSummary.tsx
@@ -3,6 +3,7 @@ import 'moment/locale/fr';
 
 import React from 'react';
 import { LucidIcon, Text } from '@/src/components/ui';
+import { SimpleLink } from '@/src/components/ui/SimpleLink';
 import { EventMode } from '@/src/constants/events';
 import { Event } from 'src/api/types';
 import {
@@ -13,17 +14,26 @@ import {
 
 export type EventInfoSummaryProps = Pick<
   Event,
-  'startDate' | 'mode' | 'meetingLink' | 'fullAddress' | 'registrationCount'
+  | 'startDate'
+  | 'mode'
+  | 'meetingLink'
+  | 'fullAddress'
+  | 'registrationCount'
+  | 'isParticipating'
 > & {
   displayParticipants?: boolean;
+  compact?: boolean;
 };
 
 export const EventInfoSummary = ({
   startDate,
   mode,
+  meetingLink,
   fullAddress,
   displayParticipants = false,
   registrationCount,
+  isParticipating,
+  compact = false,
 }: EventInfoSummaryProps) => {
   return (
     <>
@@ -48,20 +58,22 @@ export const EventInfoSummary = ({
             <LucidIcon name="Laptop" size={20} />
             <Text>
               En visio
-              {/* {meetingLink && (
+              {isParticipating && meetingLink && !compact && (
                 <>
-                  {' - '}
-                  <Link
-                    href={`${
-                      meetingLink.startsWith('http') ? '' : 'https://'
-                    }${meetingLink}`}
+                  {' : '}
+                  <SimpleLink
+                    href={
+                      meetingLink.startsWith('http')
+                        ? meetingLink
+                        : `https://${meetingLink}`
+                    }
+                    isExternal
                     target="_blank"
-                    rel="noopener noreferrer"
                   >
-                    Accéder
-                  </Link>
+                    {meetingLink}
+                  </SimpleLink>
                 </>
-              )} */}
+              )}
             </Text>
           </StyledElement>
         )}

--- a/src/features/headers/HeaderEvent/HeaderEvent.tsx
+++ b/src/features/headers/HeaderEvent/HeaderEvent.tsx
@@ -72,6 +72,7 @@ export const HeaderEvent = ({
               meetingLink={meetingLink}
               fullAddress={fullAddress}
               registrationCount={registrationCount}
+              isParticipating={isParticipating}
             />
             {isMobile && (
               <EventParticipateButton


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9087](https://entourage-asso.atlassian.net/browse/EN-9087)
**💬 Commentaire :**

This pull request enhances the `EventInfoSummary` component and its usage across the application to improve how event participation and meeting links are displayed. The main focus is on providing a more informative and context-aware summary for events, especially for participants.

**Event participation and meeting link display improvements:**

* Added the `isParticipating` and `compact` props to `EventInfoSummary`, allowing the component to conditionally show the meeting link only to participants and in non-compact mode. [[1]](diffhunk://#diff-ae39f73c4359c72b846fab0ebf8d5ef67e4a1701793c49c33daf9859e2507f5bL16-R36) [[2]](diffhunk://#diff-ae39f73c4359c72b846fab0ebf8d5ef67e4a1701793c49c33daf9859e2507f5bL51-R76)
* Updated the event card and header components (`EventCard`, `HeaderEvent`) to pass the new `isParticipating` prop, ensuring consistent behavior across the UI. [[1]](diffhunk://#diff-bacfebfbd5be0726fda83890199558ba47dd33c922f3cea8865cdde43b530502L74-R82) [[2]](diffhunk://#diff-84d07e3ab33522223a9c89d157f8e75fd21c35602833e3c9ec3e9ae7e25d0001R75)

**UI and code quality enhancements:**

* Replaced the old meeting link display with the new `SimpleLink` component for better styling and accessibility.
* Cleaned up and expanded prop definitions to improve type safety and future extensibility.
* Imported `SimpleLink` where needed.

[EN-9087]: https://entourage-asso.atlassian.net/browse/EN-9087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ