### PR TITLE
Remove event nudge and add discovery

### DIFF
--- a/cypress/fixtures/public-profile-res.json
+++ b/cypress/fixtures/public-profile-res.json
@@ -13,10 +13,10 @@
       "createdAt": "2025-04-14T00:00:00.000Z",
       "nudge": {
         "id": "f0c6c2e7-7176-41d7-bfc7-2e4d5a543f15",
-        "value": "event",
-        "nameRequest": "Se rencontrer et échanger avec les membres de la communauté",
-        "nameOffer": "Se rencontrer lors d’événements avec les membres de la communauté",
-        "order": 4
+        "value": "network",
+        "nameRequest": "Faire grandir son réseau professionnel",
+        "nameOffer": "Partager mon réseau professionnel",
+        "order": 3
       }
     }
   ],

--- a/cypress/fixtures/src/nudges/generateNudgesApiResponse.ts
+++ b/cypress/fixtures/src/nudges/generateNudgesApiResponse.ts
@@ -6,7 +6,6 @@ export const generateNudgesApiResponse = (numberOfNudges) => {
       'tips',
       'interview',
       'cv',
-      'event',
       'network',
     ]);
     return {

--- a/cypress/fixtures/src/nudges/generateNudgesApiResponse.ts
+++ b/cypress/fixtures/src/nudges/generateNudgesApiResponse.ts
@@ -7,6 +7,7 @@ export const generateNudgesApiResponse = (numberOfNudges) => {
       'interview',
       'cv',
       'network',
+      'discovery',
     ]);
     return {
       id: faker.string.uuid(),

--- a/cypress/fixtures/src/user/generateUserProfileCandidateCompleteApiResponse.ts
+++ b/cypress/fixtures/src/user/generateUserProfileCandidateCompleteApiResponse.ts
@@ -35,12 +35,10 @@ export const userProfile = () => {
         createdAt: '2025-04-14T00:00:00.000Z',
         nudge: {
           id: 'f0c6c2e7-7176-41d7-bfc7-2e4d5a543f15',
-          value: 'event',
-          nameRequest:
-            'Se rencontrer et échanger avec les membres de la communauté',
-          nameOffer:
-            'Se rencontrer lors d’événements avec les membres de la communauté',
-          order: 4,
+          value: 'network',
+          nameRequest: 'Faire grandir son réseau professionnel',
+          nameOffer: 'Partager mon réseau professionnel',
+          order: 3,
         },
       },
     ],

--- a/src/constants/nudges.tsx
+++ b/src/constants/nudges.tsx
@@ -16,7 +16,6 @@ export const nudgesIcons = {
   interview: <SvgIcon name="IlluMalette" {...iconSizeProps} />,
   cv: <SvgIcon name="IlluCV" {...iconSizeProps} />,
   network: <SvgIcon name="IlluConversation" {...iconSizeProps} />,
-  event: <SvgIcon name="IlluReseauxSociaux" {...iconSizeProps} />,
 };
 
 export const ProfileNudges: (FilterConstant<string> & {
@@ -68,21 +67,6 @@ export const ProfileNudges: (FilterConstant<string> & {
     shortTitle: {
       [UserRoles.CANDIDATE]: 'Créer mon CV',
       [UserRoles.COACH]: 'Aider à réaliser un CV',
-    },
-  },
-  {
-    icon: (
-      <LegacyImg
-        src="/static/img/illustrations/illu-disscution.png"
-        alt="Disscution"
-        {...iconSizeProps}
-      />
-    ),
-    value: 'event',
-    label: 'Événement',
-    shortTitle: {
-      [UserRoles.CANDIDATE]: 'Rencontrer la communauté',
-      [UserRoles.COACH]: 'Rencontrer la communauté',
     },
   },
   {
@@ -165,19 +149,6 @@ export const ParametresNudgeCardContents: {
     {
       icon: (
         <LegacyImg
-          src="/static/img/illustrations/illu-disscution.png"
-          alt="Disscution"
-          {...iconSizeProps}
-        />
-      ),
-      value: 'event',
-      label: 'Se rencontrer et échanger avec les membres de la communauté',
-      description:
-        "Rejoignez notre communauté lors d'événements pour partager vos expériences, apprendre des autres et tisser des liens professionnels précieux.",
-    },
-    {
-      icon: (
-        <LegacyImg
           src="/static/img/illustrations/illu-partage-rs.png"
           alt="Réseaux sociaux"
           {...iconSizeProps}
@@ -229,20 +200,6 @@ export const ParametresNudgeCardContents: {
       label: 'Aider à réaliser un CV et une lettre de motivation',
       description:
         'Utilisez votre expérience pour guider les candidats dans la création de documents professionnels qui reflètent leur potentiel et leurs expériences.',
-    },
-    {
-      icon: (
-        <LegacyImg
-          src="/static/img/illustrations/illu-disscution.png"
-          alt="Disscution"
-          {...iconSizeProps}
-        />
-      ),
-      value: 'event',
-      label:
-        'Se rencontrer lors d’événements avec les membres de la communauté',
-      description:
-        "Participer à des événements qui encouragent l'entraide, le partage d'expériences et le développement de réseaux professionnels enrichissants pour les candidats.",
     },
     {
       icon: (

--- a/src/constants/nudges.tsx
+++ b/src/constants/nudges.tsx
@@ -16,6 +16,7 @@ export const nudgesIcons = {
   interview: <SvgIcon name="IlluMalette" {...iconSizeProps} />,
   cv: <SvgIcon name="IlluCV" {...iconSizeProps} />,
   network: <SvgIcon name="IlluConversation" {...iconSizeProps} />,
+  discovery: <SvgIcon name="IlluAmpoule" {...iconSizeProps} />,
 };
 
 export const ProfileNudges: (FilterConstant<string> & {
@@ -82,6 +83,15 @@ export const ProfileNudges: (FilterConstant<string> & {
     shortTitle: {
       [UserRoles.CANDIDATE]: 'Développer mon réseau',
       [UserRoles.COACH]: 'Partager mon réseau',
+    },
+  },
+  {
+    icon: <SvgIcon name="IlluAmpoule" {...iconSizeProps} />,
+    value: 'discovery',
+    label: 'Découverte métier',
+    shortTitle: {
+      [UserRoles.CANDIDATE]: 'Découvrir un métier',
+      [UserRoles.COACH]: 'Faire découvrir mon métier',
     },
   },
 ];
@@ -159,6 +169,13 @@ export const ParametresNudgeCardContents: {
       description:
         "Multipliez les opportunités professionnelles en vous connectant avec des professionnels qui peuvent vous soutenir et vous ouvrir des portes sur le marché de l'emploi.",
     },
+    {
+      icon: <SvgIcon name="IlluAmpoule" {...iconSizeProps} />,
+      value: 'discovery',
+      label: 'Découvrir un métier',
+      description:
+        'Rencontrez des professionnels de la communauté pour explorer des métiers qui vous attirent et poser vos questions',
+    },
   ],
 
   [UserRoles.COACH]: [
@@ -213,6 +230,13 @@ export const ParametresNudgeCardContents: {
       label: 'Partager mon réseau professionnel',
       description:
         'Mettez en relation les candidats avec des contacts pertinents et intégrez-les dans des réseaux qui peuvent favoriser leur insertion professionnelle.',
+    },
+    {
+      icon: <SvgIcon name="IlluAmpoule" {...iconSizeProps} />,
+      value: 'discovery',
+      label: 'Faire découvrir mon métier',
+      description:
+        'Partagez votre quotidien, vos défis et votre parcours pour aider les candidats à explorer un métier. Votre témoignage peut ouvrir des horizons et les aider à clarifier leur projet professionnel.',
     },
   ],
 };


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9102](https://entourage-asso.atlassian.net/browse/EN-9102)
**🚧 PR-Back :** [back/467](https://github.com/ReseauEntourage/entourage-job-back/pull/467)
**💬 Commentaire :**

This pull request updates the "nudges" feature by removing the "event" nudge and introducing a new "discovery" nudge focused on career exploration. The changes include updating fixtures, constants, and UI elements to reflect this new nudge and removing all references to the old "event" nudge.

**Nudge Data and Fixture Updates:**

* The "event" nudge is removed from all user fixture data and replaced with the new "discovery" nudge, including updated titles, descriptions, and ordering. (`cypress/fixtures/public-profile-res.json`, `cypress/fixtures/src/user/generateUserProfileCandidateCompleteApiResponse.ts`) [[1]](diffhunk://#diff-c9d2d8c6f5ac2060c6ad74755cc3c49a63fc53a0ac8d8a43a8fcef1f7f93bda7L16-R19) [[2]](diffhunk://#diff-b06eea284420e04ce6b0daa4bdcc3e184f169de3afa0190d64ad44dfd70a1c96L38-R41)
* The nudge generator now includes "discovery" instead of "event" in possible nudge values. (`cypress/fixtures/src/nudges/generateNudgesApiResponse.ts`)

**Nudge Constants and UI:**

* All references to the "event" nudge are removed from the nudge constants, and a new "discovery" nudge is added with appropriate icons, labels, and descriptions for both candidates and coaches. (`src/constants/nudges.tsx`) [[1]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcL19-R19) [[2]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcL73-L87) [[3]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcR88-R96) [[4]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcL165-L177) [[5]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcR172-R178) [[6]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcL233-L246) [[7]](diffhunk://#diff-e486771043d23b5b4cd6fa2c710f405cbb7a214f92be5e6918eb5001cef8e1dcR234-R240)
* The "discovery" nudge uses the "IlluAmpoule" icon, and all UI elements are updated to reflect the new nudge.

These changes ensure that the "discovery" nudge is now available throughout the application in place of the old "event" nudge, with consistent data and visuals.

[EN-9102]: https://entourage-asso.atlassian.net/browse/EN-9102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ