### PR TITLE
[EN-9117] Display notification count in messaging icon

### DIFF
--- a/src/features/headers/Header.styles.ts
+++ b/src/features/headers/Header.styles.ts
@@ -15,11 +15,17 @@ export const StyledMessagingIconContainer = styled.div`
 
   .pin-notification {
     position: absolute;
-    top: 5px;
-    right: 5px;
-    width: 16px;
-    height: 16px;
+    top: 2px;
+    right: 2px;
+    min-width: 18px;
+    height: 18px;
+    padding: 0 3px;
     background: ${COLORS.lightRed};
-    border-radius: 50%;
+    border-radius: 8px;
+    color: white;
+    font-size: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 `;

--- a/src/features/navs/NavConnected/NavConnectedContent/NavConnectedContent.desktop.tsx
+++ b/src/features/navs/NavConnected/NavConnectedContent/NavConnectedContent.desktop.tsx
@@ -55,7 +55,7 @@ export const NavConnectedContentDesktop = ({
           color={COLORS.black}
         />
         {messaging.badge && badges[messaging.badge] > 0 && (
-          <div className="pin-notification" />
+          <div className="pin-notification">{badges[messaging.badge]}</div>
         )}
       </StyledMessagingIconContainer>
 

--- a/src/features/navs/NavConnected/NavConnectedContent/NavConnectedContent.mobile.tsx
+++ b/src/features/navs/NavConnected/NavConnectedContent/NavConnectedContent.mobile.tsx
@@ -62,7 +62,9 @@ export const NavConnectedContentMobile = ({
                 color="white"
               />
               {messaging.badge && badges[messaging.badge] > 0 && (
-                <div className="pin-notification" />
+                <div className="pin-notification">
+                  {badges[messaging.badge]}
+                </div>
               )}
             </StyledMessagingIconContainer>
             <Hamburger


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9117](https://entourage-asso.atlassian.net/browse/EN-9117)
**💬 Commentaire :**

This pull request improves the visual appearance and functionality of the messaging notification badge in both desktop and mobile navigation components. The badge now displays the actual count of unread messages and has updated styling for better visibility and alignment.

**UI/UX Improvements to Notification Badge:**

* Updated the `.pin-notification` styles in `Header.styles.ts` to increase badge size, add padding, change border radius, and center the badge content for improved appearance and readability. The badge text is now white and sized appropriately.
* Modified both `NavConnectedContent.desktop.tsx` and `NavConnectedContent.mobile.tsx` to render the actual unread message count inside the notification badge instead of displaying an empty badge. [[1]](diffhunk://#diff-485e9919c8cf35fc05076bacb5a30a0ea9165e5a2263e98debd129e89511d5ebL58-R58) [[2]](diffhunk://#diff-07042e6ccd5f3c909610cae88b6574b3f695d50ea5d2fe82177245f82c6ae70bL65-R67)

[EN-9117]: https://entourage-asso.atlassian.net/browse/EN-9117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ