### PR TITLE
Add unread conversations tab and clickable Badge component

### DIFF
--- a/src/components/ui/Badge/Badge.styles.ts
+++ b/src/components/ui/Badge/Badge.styles.ts
@@ -32,7 +32,9 @@ const badgeVariantStyles: Record<BadgeVariant, ReturnType<typeof css>> = {
 export const StyledBadge = styled.div<{
   variant: BadgeVariant;
   $borderRadius?: 'small' | 'medium' | 'large';
+  $clickable?: boolean;
 }>`
+  cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
   padding: 6px 12px;
   border-radius: ${({ $borderRadius }) => {
     switch ($borderRadius) {

--- a/src/components/ui/Badge/Badge.tsx
+++ b/src/components/ui/Badge/Badge.tsx
@@ -8,11 +8,22 @@ export interface BadgeProps {
   variant: BadgeVariant;
   children: React.ReactNode;
   borderRadius?: 'small' | 'medium' | 'large';
+  onClick?: () => void;
 }
 
-export const Badge = ({ variant, children, borderRadius }: BadgeProps) => {
+export const Badge = ({
+  variant,
+  children,
+  borderRadius,
+  onClick,
+}: BadgeProps) => {
   return (
-    <StyledBadge variant={variant} $borderRadius={borderRadius}>
+    <StyledBadge
+      variant={variant}
+      $borderRadius={borderRadius}
+      $clickable={!!onClick}
+      onClick={onClick}
+    >
       {children}
     </StyledBadge>
   );

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.styles.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.styles.tsx
@@ -25,3 +25,7 @@ export const StyledConversationsContainer = styled.div`
     height: 100%;
   }
 `;
+
+export const StyledEmptyState = styled.p`
+  padding: 30px 15px;
+`;

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.tsx
@@ -1,5 +1,7 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { conversationHasUnreadMessages } from '../messaging.utils';
+import { Text } from 'src/components/ui';
 import { SearchBar } from 'src/features/filters/SearchBar/SearchBar';
 import { useIsMobile } from 'src/hooks/utils';
 import { selectCurrentUserId } from 'src/use-cases/current-user';
@@ -7,31 +9,45 @@ import { messagingActions, selectConversations } from 'src/use-cases/messaging';
 import {
   ContainerStyled,
   StyledConversationsContainer,
+  StyledEmptyState,
   StyledSearchBarContainer,
 } from './MessagingConversationList.styles';
 import { MessagingConversationListItem } from './MessagingConversationListItem/MessagingConversationListItem';
+import {
+  ConversationTabFilter,
+  MessagingConversationTabs,
+} from './MessagingConversationTabs/MessagingConversationTabs';
 
 export const MessagingConversationList = () => {
   const dispatch = useDispatch();
   const allConversations = useSelector(selectConversations);
   const currentUserId = useSelector(selectCurrentUserId);
-  const [conversations, setConversations] = useState(allConversations);
   const [query, setQuery] = useState('');
+  const [activeTab, setActiveTab] = useState<ConversationTabFilter>('all');
   const isMobile = useIsMobile();
 
   useEffect(() => {
     dispatch(messagingActions.getConversationsRequested());
   }, [dispatch]);
 
-  useEffect(() => {
+  const unreadCount = useMemo(() => {
+    if (!allConversations || !currentUserId) {
+      return 0;
+    }
+    return allConversations.filter((c) =>
+      conversationHasUnreadMessages(c, currentUserId)
+    ).length;
+  }, [allConversations, currentUserId]);
+
+  const conversations = useMemo(() => {
     if (!allConversations) {
-      return setConversations(null);
+      return null;
     }
-    if (!query) {
-      return setConversations(allConversations);
-    }
-    setConversations(
-      allConversations.filter((conversation) =>
+
+    let filtered = allConversations;
+
+    if (query) {
+      filtered = filtered.filter((conversation) =>
         conversation.participants
           .filter((participant) => participant.id !== currentUserId)
           .some(
@@ -41,9 +57,22 @@ export const MessagingConversationList = () => {
                 .includes(query.toLowerCase()) ||
               participant.lastName.toLowerCase().includes(query.toLowerCase())
           )
-      )
-    );
-  }, [allConversations, currentUserId, query]);
+      );
+    }
+
+    if (activeTab === 'unread') {
+      return filtered.filter((c) =>
+        conversationHasUnreadMessages(c, currentUserId)
+      );
+    }
+
+    // Sort unread conversations first in the "all" tab
+    return [...filtered].sort((a, b) => {
+      const aUnread = conversationHasUnreadMessages(a, currentUserId) ? 1 : 0;
+      const bUnread = conversationHasUnreadMessages(b, currentUserId) ? 1 : 0;
+      return bUnread - aUnread;
+    });
+  }, [allConversations, currentUserId, query, activeTab]);
 
   const setSearch = useCallback((search) => {
     setQuery(search);
@@ -51,6 +80,11 @@ export const MessagingConversationList = () => {
 
   return (
     <ContainerStyled>
+      <MessagingConversationTabs
+        activeTab={activeTab}
+        unreadCount={unreadCount}
+        onTabChange={setActiveTab}
+      />
       {!isMobile && (
         <StyledSearchBarContainer>
           <SearchBar
@@ -71,6 +105,13 @@ export const MessagingConversationList = () => {
               conversation={conversation}
             />
           ))}
+        {conversations &&
+          conversations.length === 0 &&
+          activeTab === 'unread' && (
+            <StyledEmptyState>
+              <Text center>Aucune conversation non lue</Text>
+            </StyledEmptyState>
+          )}
       </StyledConversationsContainer>
     </ContainerStyled>
   );

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationListItem/MessagingConversationListItem.styles.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationListItem/MessagingConversationListItem.styles.tsx
@@ -20,7 +20,19 @@ export const ContainerStyled = styled.div<{ isActive: boolean }>`
 `;
 
 export const ContainerAvatarStyled = styled.div`
+  position: relative;
   align-items: flex-start;
+`;
+
+export const StyledUnreadDot = styled.span`
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background-color: ${COLORS.darkBlue};
+  border: 2px solid ${COLORS.white};
 `;
 
 export const RightColumn = styled.div<{ highlight: boolean }>`

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationListItem/MessagingConversationListItem.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationListItem/MessagingConversationListItem.tsx
@@ -15,6 +15,7 @@ import {
   MainInfos,
   ContainerStyled,
   RightColumn,
+  StyledUnreadDot,
 } from './MessagingConversationListItem.styles';
 
 interface MessagingConversationListItemProps {
@@ -60,6 +61,7 @@ export const MessagingConversationListItem = ({
             hasPicture={addresee.userProfile?.hasPicture || false}
           />
         )}
+        {hasUnreadMessages && <StyledUnreadDot />}
       </ContainerAvatarStyled>
       <RightColumn highlight={shouldHighlightConversation}>
         <MainInfos>

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationTabs/MessagingConversationTabs.styles.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationTabs/MessagingConversationTabs.styles.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+import { COLORS } from 'src/constants/styles';
+
+export const StyledTabsContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  padding: 12px 15px;
+  border-bottom: 2px solid ${COLORS.lightGray};
+  flex-shrink: 0;
+`;

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationTabs/MessagingConversationTabs.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationTabs/MessagingConversationTabs.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Badge, BadgeVariant } from 'src/components/ui/Badge';
+import { StyledTabsContainer } from './MessagingConversationTabs.styles';
+
+export type ConversationTabFilter = 'all' | 'unread';
+
+interface MessagingConversationTabsProps {
+  activeTab: ConversationTabFilter;
+  unreadCount: number;
+  onTabChange: (tab: ConversationTabFilter) => void;
+}
+
+export const MessagingConversationTabs = ({
+  activeTab,
+  unreadCount,
+  onTabChange,
+}: MessagingConversationTabsProps) => {
+  return (
+    <StyledTabsContainer>
+      <Badge
+        variant={
+          activeTab === 'all' ? BadgeVariant.Primary : BadgeVariant.HoverBlue
+        }
+        borderRadius="large"
+        onClick={() => onTabChange('all')}
+      >
+        Tous
+      </Badge>
+      <Badge
+        variant={
+          activeTab === 'unread' ? BadgeVariant.Primary : BadgeVariant.HoverBlue
+        }
+        borderRadius="large"
+        onClick={() => onTabChange('unread')}
+      >
+        Non lus · {unreadCount}
+      </Badge>
+    </StyledTabsContainer>
+  );
+};


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9089](https://entourage-asso.atlassian.net/browse/EN-9089)
**🚧 PR-Back :** N/A
**💬 Commentaire :**

This pull request adds a new tab-based filtering system to the messaging conversations list, allowing users to easily switch between viewing all conversations or only unread ones. It also introduces visual improvements, such as an unread indicator dot on conversations with unread messages, and makes badges clickable for improved UI interactivity.

**Messaging Conversations List Improvements:**

* Added a tab bar (`MessagingConversationTabs`) to filter conversations by "all" or "unread", including a count of unread conversations and sorting unread conversations to the top in the "all" tab. [[1]](diffhunk://#diff-aef51f9df69420396dbf8d3bc9608529abf0de892172dd6ae61372ad380166aaL1-R50) [[2]](diffhunk://#diff-aef51f9df69420396dbf8d3bc9608529abf0de892172dd6ae61372ad380166aaL44-R87) [[3]](diffhunk://#diff-c7f1b1cba0c88e2159287e406ad02aac9c79e9bcbe3cf21ce40410d96ace1405R1-R40)
* Added an empty state message ("Aucune conversation non lue") when there are no unread conversations in the "unread" tab. [[1]](diffhunk://#diff-7f34411d50f0245a36c4602ba8e6607e70fc2902f1e8b31fbbbd72cd451a35a2R28-R31) [[2]](diffhunk://#diff-aef51f9df69420396dbf8d3bc9608529abf0de892172dd6ae61372ad380166aaR108-R114)

**Unread Message Visual Indicator:**

* Added a visual unread dot (`StyledUnreadDot`) to conversation list items with unread messages for better visibility. [[1]](diffhunk://#diff-4ddf67e53fc8c08f5b440ae00c33fd4a91864c079ceb3ef93d728fa4711ace97R23-R37) [[2]](diffhunk://#diff-aa638527523492e237e31a3db47771ade7ec43290f98e021fcf688dd58b3a6afR18) [[3]](diffhunk://#diff-aa638527523492e237e31a3db47771ade7ec43290f98e021fcf688dd58b3a6afR64)

**Badge Component Enhancements:**

* Updated the `Badge` component to support click handlers and a pointer cursor when clickable, enabling its use as a tab selector. [[1]](diffhunk://#diff-77c432c9939e39b6cb66b718725a427af0a0b319a7b02922bff6b09030db6f3eR35-R37) [[2]](diffhunk://#diff-66735d99045607b665e7adf6fd90bb5164aa056ab59020a5363a5b442021fed5R11-R26)

**Styling Additions:**

* Introduced new styled components for the tab bar and empty state to support the enhanced UI. [[1]](diffhunk://#diff-de593d685d28dbce7b4c74530d67802c3fde0967c95f09976c0040f24d78d6d8R1-R10) [[2]](diffhunk://#diff-7f34411d50f0245a36c4602ba8e6607e70fc2902f1e8b31fbbbd72cd451a35a2R28-R31)

[EN-9089]: https://entourage-asso.atlassian.net/browse/EN-9089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ