### PR TITLE
Refactor API responses to remove address references and components

### DIFF
--- a/cypress/fixtures/auth-current-candidate-onboarding-completed-res.json
+++ b/cypress/fixtures/auth-current-candidate-onboarding-completed-res.json
@@ -9,7 +9,6 @@
   "lastName": "Fring",
   "email": "gustavo.fring@entourage.social",
   "phone": "+33606060606",
-  "address": null,
   "role": "Coach",
   "zone": "LILLE",
   "gender": 0,

--- a/cypress/fixtures/auth-current-candidate-onboarding-not-started-res.json
+++ b/cypress/fixtures/auth-current-candidate-onboarding-not-started-res.json
@@ -9,7 +9,6 @@
   "lastName": "Fring",
   "email": "gustavo.fring@entourage.social",
   "phone": "+33606060606",
-  "address": null,
   "role": "Candidat",
   "zone": "LILLE",
   "gender": 0,

--- a/cypress/fixtures/auth-current-referer-res.json
+++ b/cypress/fixtures/auth-current-referer-res.json
@@ -4,7 +4,6 @@
   "lastName": "Fleuri",
   "email": "m.fleuri@interflora.fr",
   "phone": "0123456789",
-  "address": "3 rue des caribous",
   "role": "Prescripteur",
   "zone": "PARIS",
   "gender": 0,

--- a/cypress/fixtures/src/login/generateAdminLoginApiResponse.ts
+++ b/cypress/fixtures/src/login/generateAdminLoginApiResponse.ts
@@ -8,7 +8,6 @@ export const generateAdminLoginApiResponse = () => {
     lastName: 'Doe',
     gender: 0,
     phone: faker.phone.number(),
-    address: '01 rue Acme, 75001 Paris',
     zone: 'Paris',
     role: 'Admin',
     candidat: false,

--- a/cypress/fixtures/src/login/generateUserLoginApiResponse.ts
+++ b/cypress/fixtures/src/login/generateUserLoginApiResponse.ts
@@ -8,7 +8,6 @@ export const generateUserLoginApiResponse = (roleUser) => {
     lastName: faker.person.lastName(),
     email: faker.internet.exampleEmail(),
     phone: faker.phone.number(),
-    address: null,
     zone: 'PARIS',
     gender: 0,
     lastConnection: '',

--- a/cypress/fixtures/src/user/generateUsersApiResponse.ts
+++ b/cypress/fixtures/src/user/generateUsersApiResponse.ts
@@ -7,7 +7,6 @@ export const generateUsersApiResponse = (numbersOfUsers, roleUsers) => {
     lastName: faker.person.lastName(),
     email: faker.internet.email(),
     phone: faker.phone.number(),
-    address: faker.location.streetAddress(),
     role: roleUsers,
     zone: faker.location.city(),
     gender: faker.number.int(1),

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -289,7 +289,6 @@ export type User = {
   salt: string;
   gender: Genders;
   phone: string;
-  address: string;
   lastConnection: string;
   hashReset: string;
   saltReset: string;

--- a/src/features/backoffice/admin/members/MemberDetails/EditMemberModal.tsx
+++ b/src/features/backoffice/admin/members/MemberDetails/EditMemberModal.tsx
@@ -80,7 +80,6 @@ export function EditMemberModal({ user, setUser }: EditMemberModalProps) {
         role: user.role,
         gender: user.gender,
         phone: user.phone,
-        address: user.address,
         zone: user.zone,
         organizationId: organization,
       },

--- a/src/features/backoffice/admin/members/MemberDetails/MemberTab/ParametersMemberTab.tsx
+++ b/src/features/backoffice/admin/members/MemberDetails/MemberTab/ParametersMemberTab.tsx
@@ -83,13 +83,7 @@ export function ParametersMemberTab({
   );
 
   const memberColumns: MemberColumn[] = useMemo(() => {
-    const columnsToShow: MemberColumn[] = [
-      'phone',
-      'gender',
-      'address',
-      'zone',
-      'cvUrl',
-    ];
+    const columnsToShow: MemberColumn[] = ['phone', 'gender', 'zone', 'cvUrl'];
 
     if (user && isRoleIncluded([UserRoles.REFERER], user.role)) {
       return [...columnsToShow, 'organization'];

--- a/src/features/backoffice/admin/members/MemberTable/Member/Member.desktop.tsx
+++ b/src/features/backoffice/admin/members/MemberTable/Member/Member.desktop.tsx
@@ -58,11 +58,6 @@ export function MemberDesktop({ member, columns, disableLink }: MemberProps) {
           </StyledNoWrapCellContent>
         </TdDesktop>
       )}
-      {columns.includes('address') && (
-        <TdDesktop>
-          <span>{member.address || '-'}</span>
-        </TdDesktop>
-      )}
       {columns.includes('zone') && (
         <TdDesktop>
           <StyledNoWrapCellContent>

--- a/src/features/backoffice/admin/members/MemberTable/Member/Member.mobile.tsx
+++ b/src/features/backoffice/admin/members/MemberTable/Member/Member.mobile.tsx
@@ -62,11 +62,6 @@ export function MemberMobile({ member, columns, disableLink }: MemberProps) {
             <span>{member.organization?.name || '-'}</span>
           </TdMobile>
         )}
-        {columns.includes('address') && (
-          <TdMobile title="Adresse">
-            <span>{member.address || '-'}</span>
-          </TdMobile>
-        )}
         {columns.includes('zone') && (
           <TdMobile title="Zone">
             <span>

--- a/src/features/backoffice/admin/members/MemberTable/Member/Member.types.ts
+++ b/src/features/backoffice/admin/members/MemberTable/Member/Member.types.ts
@@ -5,7 +5,6 @@ export type MemberColumn =
   | 'type'
   | 'zone'
   | 'lastConnection'
-  | 'address'
   | 'gender'
   | 'phone'
   | 'cvUrl'

--- a/src/features/backoffice/admin/members/MemberTable/MemberTable.tsx
+++ b/src/features/backoffice/admin/members/MemberTable/MemberTable.tsx
@@ -59,15 +59,6 @@ export function MemberTable({ columns, members, role }: MemberTableProps) {
       ];
     }
 
-    if (columns.includes('address')) {
-      columnsArray = [
-        // @ts-expect-error after enable TS strict mode. Please, try to fix it
-        ...columnsArray,
-        // @ts-expect-error after enable TS strict mode. Please, try to fix it
-        <Th key="memberAddress">Adresse</Th>,
-      ];
-    }
-
     if (columns.includes('organization')) {
       columnsArray = [
         // @ts-expect-error after enable TS strict mode. Please, try to fix it

--- a/src/features/forms/schemas/formPersonalData.ts
+++ b/src/features/forms/schemas/formPersonalData.ts
@@ -13,7 +13,6 @@ export const formPersonalDataAsCandidate: FormSchema<{
   firstName: string;
   lastName: string;
   phone: string;
-  address: string;
   oldEmail: string;
   newEmail0: string;
   newEmail1: string;

--- a/src/features/profile/CVPDF/CVContactInformationPDF.tsx
+++ b/src/features/profile/CVPDF/CVContactInformationPDF.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import {
-  DepartmentName,
-  DEPARTMENTS_FILTERS,
-} from 'src/constants/departements';
-import { findConstantFromValue, sortByOrder } from 'src/utils';
-import {
   StyledCVPDFContentInformations,
   StyledCVPDFTitle,
 } from './CVPDF.styles';
@@ -13,19 +8,12 @@ import {
 interface ContactInformationPDFProps {
   phone: string;
   email?: string;
-  departments?: {
-    name: DepartmentName;
-    order: number;
-  }[];
 }
 
 export function CVContactInformationPDF({
   phone,
   email,
-  departments,
 }: ContactInformationPDFProps) {
-  const sortedDepartments =
-    departments && departments.length > 0 ? sortByOrder(departments) : [];
   return (
     <StyledCVPDFContentInformations>
       <StyledCVPDFTitle>Contact</StyledCVPDFTitle>
@@ -46,21 +34,6 @@ export function CVContactInformationPDF({
             <p className="content">{email}</p>
           </li>
         )}
-        {/* DEPRECATED => : */}
-        {sortedDepartments && sortedDepartments.length > 0 && (
-          <li>
-            <p className="subtitle">
-              <LucidIcon name="MapPin" /> <span>Localisation</span>
-            </p>
-            {sortedDepartments?.length &&
-              sortedDepartments
-                .map(({ name }) => {
-                  return findConstantFromValue(name, DEPARTMENTS_FILTERS).label;
-                })
-                .join(' / ')}
-          </li>
-        )}
-        {/* <= DEPRECATED */}
       </ul>
     </StyledCVPDFContentInformations>
   );

--- a/src/features/profile/CVPDF/CVPDF.tsx
+++ b/src/features/profile/CVPDF/CVPDF.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import 'moment/locale/fr';
 
 import { Text } from '@/src/components/ui';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
@@ -30,7 +31,6 @@ import {
   StyledCVPFSkillTag,
 } from './CVPDF.styles';
 import { CVProfilePicturePDF } from './CVProfilePicturePDF';
-import 'moment/locale/fr';
 
 const BASE_NB_ITEM_PER_PAGE = 5;
 const MAX_LINES_BY_ITEM = 9;
@@ -187,11 +187,7 @@ export const CVPDF = ({ user, page }: CVPDFProps) => {
       <StyledCVPDFContentDetailsContainer>
         <StyledLeftColumn>
           {/* use Information Container to display contat informations */}
-          <CVContactInformationPDF
-            // departments={user.userProfile.departments}
-            email={user.email}
-            phone={user.phone}
-          />
+          <CVContactInformationPDF email={user.email} phone={user.phone} />
           <StyledCVPDFContentInformations>
             <StyledCVPDFTitle>Informations</StyledCVPDFTitle>
             <ul>
@@ -321,19 +317,11 @@ export const CVPDF = ({ user, page }: CVPDFProps) => {
         <StyledCVPDFPage>
           <StyledCVPDFContentDetailsContainer>
             <StyledLeftColumn>
-              {/* use Information Container to display profile picture */}
               <StyledCVPDFContentInformations>
                 <StyledCVPDFProfilePictureContainer>
                   <CVProfilePicturePDF imgSrc={imgSrc} verticalMargin />
                 </StyledCVPDFProfilePictureContainer>
               </StyledCVPDFContentInformations>
-              {/* use Information Container to display contact information */}
-              {/* <CVContactInformationPDF
-                locations={publicCV.userProfile.locations}
-                address={publicCV.userProfile.address}
-                email={publicCV.userProfile.email}
-                phone={publicCV.userProfile.phone}
-              /> */}
             </StyledLeftColumn>
             <StyledRightColumn>
               {items.secondPageExperiences.length > 0 && (


### PR DESCRIPTION
This pull request removes all usage and references to the `address` field from user/member data structures, fixtures, and UI components across the codebase. This change simplifies user data handling and ensures consistency by eliminating the now-unused `address` property.

**Removal of address field from user data and types:**

* Removed the `address` property from the `User` type in `src/api/types.ts`, as well as from related form schemas and generated API responses. [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feL292) [[2]](diffhunk://#diff-9f12dc034dbe0c772b26f82129b036180b9ba60e6c214ff6a5da5c66cfe800c5L16) [[3]](diffhunk://#diff-a6d82df686df98bba47902a83f07cfc580316e90f763e2713753aa16ca942daaL11) [[4]](diffhunk://#diff-662315191ae855204ea20372256d4644eddbf63075a683946a5f09c6454d284eL11) [[5]](diffhunk://#diff-4c41aca142e79ee8b023d81a9f7db1c12af86e7e5eae1fcfb69ef6330be324e3L10)

**Fixture and mock data updates:**

* Deleted the `address` field from all relevant Cypress fixture files and mock API response generators. [[1]](diffhunk://#diff-efa37c0bc1c0b594f72c75c9d73831ade07108ca32b80cd0a6f6cce936daea23L12) [[2]](diffhunk://#diff-2e53382106e77f5e4ec1c00b9b2ca515003d5313a8607bf90cb1bbb5f1ac336eL12) [[3]](diffhunk://#diff-904131ca405b8f73ce5701b3b51d981890e99e1a7536b7e3b5db911181f89e7bL7) [[4]](diffhunk://#diff-662315191ae855204ea20372256d4644eddbf63075a683946a5f09c6454d284eL11) [[5]](diffhunk://#diff-a6d82df686df98bba47902a83f07cfc580316e90f763e2713753aa16ca942daaL11) [[6]](diffhunk://#diff-4c41aca142e79ee8b023d81a9f7db1c12af86e7e5eae1fcfb69ef6330be324e3L10)

**UI component and table updates:**

* Removed the `address` column from member tables, both in desktop and mobile views, and from the list of available columns. [[1]](diffhunk://#diff-f250912c471e6dc75e6d40e2092a27aea8f3a0e6034e2c73c16d327674bc317fL61-L65) [[2]](diffhunk://#diff-5e0030da50c4755f9e572cfefb30b7125a7b187d4d1876882898abf1772688ceL65-L69) [[3]](diffhunk://#diff-c27ef35c1b4ee8cbf3873568e001fb0a1446c482a45b65a83fa157e254c1fd3dL86-R86) [[4]](diffhunk://#diff-22cc6c02e7dfaaea8e9d17be6172ed891e5a74f16a1a2db72b30beae2b1fade1L8) [[5]](diffhunk://#diff-430f1e49dc63d6e2c87ce9f34c953a4dd47673076658dc93e28ad5f6f0e6306aL62-L70)

**Profile and CV PDF components:**

* Cleaned up the CV PDF components by removing deprecated or unused address/location/department-related code and props from `CVContactInformationPDF` and its usage in `CVPDF`. [[1]](diffhunk://#diff-4e2aa6ab20243ceaf7550fdd2e7e93748711a71eac0a9cd454bfec0af6415142L3-L7) [[2]](diffhunk://#diff-4e2aa6ab20243ceaf7550fdd2e7e93748711a71eac0a9cd454bfec0af6415142L16-L28) [[3]](diffhunk://#diff-4e2aa6ab20243ceaf7550fdd2e7e93748711a71eac0a9cd454bfec0af6415142L49-L63) [[4]](diffhunk://#diff-5341f28013759bbca98df10e733fc478ae6608efab8b5a72bf736da58ed8d4abR2) [[5]](diffhunk://#diff-5341f28013759bbca98df10e733fc478ae6608efab8b5a72bf736da58ed8d4abL33) [[6]](diffhunk://#diff-5341f28013759bbca98df10e733fc478ae6608efab8b5a72bf736da58ed8d4abL190-R190) [[7]](diffhunk://#diff-5341f28013759bbca98df10e733fc478ae6608efab8b5a72bf736da58ed8d4abL324-L336)

**Form and modal updates:**

* Removed the `address` field from member edit modals and related form data handling.

These changes collectively ensure that the `address` field is no longer present or expected anywhere in the application.