### PR TITLE
Add beta feature management for AI in messaging conversation

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -288,6 +288,10 @@ export type UserStats = {
   totalConversationWithMirrorRoleCount: number | null;
 };
 
+export enum FeatureKey {
+  MESSAGING_AI_ASSISTANT = 'messaging_ai_assistant',
+}
+
 export type User = {
   id: string;
   createdAt?: string;
@@ -305,6 +309,7 @@ export type User = {
   onboardingStatus: OnboardingStatus;
   onboardingCompletedAt: string | null;
   onboardingWebinarSkippedAt: string | null;
+  betaFeatures: Record<string, boolean>;
 };
 
 export type MemberUser = User & {
@@ -372,6 +377,7 @@ export type CurrentUserIdentity = {
   onboardingStatus: OnboardingStatus;
   onboardingCompletedAt: string | null;
   onboardingWebinarSkippedAt: string | null;
+  betaFeatures: Record<string, boolean>;
 };
 
 export type CurrentUserProfile = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -309,7 +309,7 @@ export type User = {
   onboardingStatus: OnboardingStatus;
   onboardingCompletedAt: string | null;
   onboardingWebinarSkippedAt: string | null;
-  betaFeatures: Record<string, boolean>;
+  betaFeatures: Record<FeatureKey, boolean>;
 };
 
 export type MemberUser = User & {
@@ -377,7 +377,7 @@ export type CurrentUserIdentity = {
   onboardingStatus: OnboardingStatus;
   onboardingCompletedAt: string | null;
   onboardingWebinarSkippedAt: string | null;
-  betaFeatures: Record<string, boolean>;
+  betaFeatures: Record<FeatureKey, boolean>;
 };
 
 export type CurrentUserProfile = {

--- a/src/features/backoffice/messaging/MessagingAIPanel/MessagingAIPanel.tsx
+++ b/src/features/backoffice/messaging/MessagingAIPanel/MessagingAIPanel.tsx
@@ -22,7 +22,7 @@ interface PanelTabConfig {
 }
 
 const PANEL_TABS: PanelTabConfig[] = [
-  { view: 'ai', label: 'Assistant IA', icon: 'Sparkles' },
+  { view: 'ai', label: 'Assistant Coach', icon: 'Sparkles' },
 ];
 
 export const MessagingAIPanel = () => {

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.styles.ts
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.styles.ts
@@ -1,44 +1,6 @@
 import styled from 'styled-components';
 import { COLORS } from 'src/constants/styles';
 
-export const MessagingPanelSidebarContainer = styled.div`
-  width: 40px;
-  border-left: 1px solid ${COLORS.lightGray};
-  height: 100%;
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 8px 0;
-  background: ${COLORS.white};
-`;
-
-export const PanelSidebarButton = styled.button`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 8px;
-  padding: 16px 0;
-  width: 100%;
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: ${COLORS.mediumGray};
-  transition: color 0.15s ease, background 0.15s ease;
-
-  &:hover {
-    color: ${COLORS.primaryBlue};
-    background: #f0f4ff;
-  }
-`;
-
-export const PanelSidebarLabel = styled.span`
-  font-size: 11px;
-  writing-mode: vertical-rl;
-  transform: rotate(180deg);
-  white-space: nowrap;
-`;
-
 export const MessagingConversationWrapper = styled.div`
   display: flex;
   flex-direction: row;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
@@ -3,12 +3,14 @@ import { useDispatch, useSelector } from 'react-redux';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { MessagingAIPanel } from '../MessagingAIPanel';
 import { MessagingEmptyState } from '../MessagingEmptyState';
+import { FeatureKey } from 'src/api/types';
 import { DELAY_REFRESH_CONVERSATIONS } from 'src/constants';
 import { UserRoles } from 'src/constants/users';
 import { useIsMobile } from 'src/hooks/utils';
 import {
   selectCurrentUser,
   selectCurrentUserId,
+  selectHasBetaFeature,
 } from 'src/use-cases/current-user';
 import {
   messagingActions,
@@ -57,6 +59,9 @@ export const MessagingConversation = () => {
   const isMobile = useIsMobile();
   const currentUser = useSelector(selectCurrentUser);
   const currentUserId = useSelector(selectCurrentUserId);
+  const hasMessagingAIAssistant = useSelector(
+    selectHasBetaFeature(FeatureKey.MESSAGING_AI_ASSISTANT)
+  );
   const selectedConversationId = useSelector(selectSelectedConversationId);
   const selectedConversation = useSelector(selectSelectedConversation);
   const newMessage = useSelector(selectNewMessage);
@@ -234,7 +239,9 @@ export const MessagingConversation = () => {
       (p) => p.role === UserRoles.CANDIDATE
     ) ?? false;
   const canUseAIAssistant =
-    currentUser?.role !== UserRoles.CANDIDATE && conversationHasCandidate;
+    currentUser?.role !== UserRoles.CANDIDATE &&
+    conversationHasCandidate &&
+    hasMessagingAIAssistant;
   const isNewConversation = selectedConversationId === 'new';
   const showAIPanelMobile =
     isMobile && canUseAIAssistant && isAIPanelOpen && !isNewConversation;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { MessagingAIPanel } from '../MessagingAIPanel';
 import { MessagingEmptyState } from '../MessagingEmptyState';
 import { FeatureKey } from 'src/api/types';
@@ -25,15 +24,11 @@ import {
   selectNewMessage,
   selectShouldGiveFeedback,
 } from 'src/use-cases/messaging/messaging.selectors';
-import type { MessagingPanelView } from 'src/use-cases/messaging/messaging.slice';
 import {
   MessagingConversationAIPanel,
   MessagingConversationContainer,
   MessagingConversationWrapper,
   MessagingMessagesContainer,
-  MessagingPanelSidebarContainer,
-  PanelSidebarButton,
-  PanelSidebarLabel,
 } from './MessagingConversation.styles';
 import { MessagingConversationHeader } from './MessagingConversationHeader/MessagingConversationHeader';
 import { MessagingEditor } from './MessagingEditor/MessagingEditor';
@@ -43,16 +38,6 @@ import { MessagingMessage } from './MessagingMessage/MessagingMessage';
 import { MessagingPinnedInfo } from './MessagingPinnedInfo/MessagingPinnedInfo';
 import { MessagingSuggestions } from './MessagingSuggestions/MessagingSuggestions';
 import { MessagingSuggestionItem } from './MessagingSuggestions/MessagingSuggestions.types';
-
-interface PanelOption {
-  view: MessagingPanelView;
-  label: string;
-  icon: string;
-}
-
-const PANEL_OPTIONS: PanelOption[] = [
-  { view: 'ai', label: 'Assistant IA', icon: 'Sparkles' },
-];
 
 export const MessagingConversation = () => {
   const dispatch = useDispatch();
@@ -245,16 +230,6 @@ export const MessagingConversation = () => {
   const isNewConversation = selectedConversationId === 'new';
   const showAIPanelMobile =
     isMobile && canUseAIAssistant && isAIPanelOpen && !isNewConversation;
-  const showPanelSidebar =
-    !isMobile &&
-    canUseAIAssistant &&
-    !!selectedConversationId &&
-    !isAIPanelOpen &&
-    !isNewConversation;
-
-  const onOpenPanel = (view: MessagingPanelView) => {
-    dispatch(messagingActions.setActivePanelView(view));
-  };
 
   const conversationContent = (
     <>
@@ -333,19 +308,6 @@ export const MessagingConversation = () => {
       <MessagingConversationContainer className={isMobile ? 'mobile' : ''}>
         {conversationContent}
       </MessagingConversationContainer>
-      {showPanelSidebar && (
-        <MessagingPanelSidebarContainer>
-          {PANEL_OPTIONS.map((option) => (
-            <PanelSidebarButton
-              key={option.view}
-              onClick={() => onOpenPanel(option.view)}
-            >
-              <LucidIcon name={option.icon as any} size={18} />
-              <PanelSidebarLabel>{option.label}</PanelSidebarLabel>
-            </PanelSidebarButton>
-          ))}
-        </MessagingPanelSidebarContainer>
-      )}
       {!isMobile &&
         isAIPanelOpen &&
         canUseAIAssistant &&

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.styles.ts
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.styles.ts
@@ -12,9 +12,6 @@ export const MessagingConversationHeaderContainer = styled.div`
   align-items: center;
   gap: 12px;
 
-  a.report-link {
-    color: ${COLORS.mediumGray};
-  }
   &.mobile {
     background: ${COLORS.white};
     position: sticky;
@@ -50,12 +47,8 @@ export const ConversationAddresee = styled.div`
   }
 `;
 
-export const ActionMenuIconStyled = styled.div`
+export const StyledButtonContainer = styled.div`
   display: flex;
-  justify-content: center;
-  padding: 5px;
-  border-radius: 50%;
-  border: ${COLORS.gray} 1px solid;
-  transition: 0.3s ease-in-out;
-  color: ${COLORS.gray};
+  gap: 15px;
+  align-items: center;
 `;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
@@ -12,11 +12,13 @@ import {
   ConversationParticipant,
   ConversationParticipants,
 } from 'src/api/types';
+import { FeatureKey } from 'src/api/types';
 import { UserRoles } from 'src/constants/users';
 import { useIsMobile } from 'src/hooks/utils';
 import {
   selectCurrentUser,
   selectCurrentUserId,
+  selectHasBetaFeature,
 } from 'src/use-cases/current-user';
 import {
   messagingActions,
@@ -52,6 +54,9 @@ export const MessagingConversationHeader = () => {
   const selectedConversation = useSelector(selectSelectedConversation);
   const currentUserId = useSelector(selectCurrentUserId);
   const currentUser = useSelector(selectCurrentUser);
+  const hasMessagingAIAssistant = useSelector(
+    selectHasBetaFeature(FeatureKey.MESSAGING_AI_ASSISTANT)
+  );
   const isAIPanelOpen = useSelector(selectIsAIPanelOpen);
   const activePanelView = useSelector(selectActivePanelView);
   const addresees = selectedConversation?.participants.filter(
@@ -59,7 +64,8 @@ export const MessagingConversationHeader = () => {
   ) as ConversationParticipants;
   const addresee = addresees ? (addresees[0] as ConversationParticipant) : null;
 
-  const canUseAIAssistant = currentUser?.role !== UserRoles.CANDIDATE;
+  const canUseAIAssistant =
+    currentUser?.role !== UserRoles.CANDIDATE && hasMessagingAIAssistant;
   const showMobilePanelMenu =
     isMobile &&
     canUseAIAssistant &&

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
@@ -1,10 +1,8 @@
 import { useRouter } from 'next/router';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Badge, BadgeVariant, ImgUserProfile } from '@/src/components/ui';
+import { Button, ImgUserProfile } from '@/src/components/ui';
 import { ButtonIcon } from '@/src/components/ui/Button/ButtonIcon';
-import { Dropdown } from '@/src/components/ui/Dropdown/Dropdown';
-import { DropdownToggle } from '@/src/components/ui/Dropdown/DropdownToggle';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { openModal } from '@/src/features/modals/Modal';
 import { MessagingConversationReportModal } from '../MessagingConversationReport/MessagingConversationReportModal';
@@ -29,22 +27,12 @@ import {
 } from 'src/use-cases/messaging';
 import type { MessagingPanelView } from 'src/use-cases/messaging/messaging.slice';
 import {
-  ActionMenuIconStyled,
   AddreseeInfosContainer,
   ConversationAddresee,
   LeftColumn,
   MessagingConversationHeaderContainer,
+  StyledButtonContainer,
 } from './MessagingConversationHeader.styles';
-
-interface PanelOption {
-  view: MessagingPanelView;
-  label: string;
-  icon: string;
-}
-
-const PANEL_OPTIONS: PanelOption[] = [
-  { view: 'ai', label: 'Assistant IA', icon: 'Sparkles' },
-];
 
 export const MessagingConversationHeader = () => {
   const dispatch = useDispatch();
@@ -66,11 +54,6 @@ export const MessagingConversationHeader = () => {
 
   const canUseAIAssistant =
     currentUser?.role !== UserRoles.CANDIDATE && hasMessagingAIAssistant;
-  const showMobilePanelMenu =
-    isMobile &&
-    canUseAIAssistant &&
-    selectedConversationId !== null &&
-    selectedConversationId !== 'new';
 
   const onClickBackBtn = () => {
     dispatch(messagingActions.selectConversation(null));
@@ -126,46 +109,23 @@ export const MessagingConversationHeader = () => {
           </AddreseeInfosContainer>
         )}
       </LeftColumn>
-      {showMobilePanelMenu && (
-        <Dropdown>
-          <DropdownToggle>
-            <Badge variant={BadgeVariant.HoverBlue} borderRadius="medium">
-              <LucidIcon name="Menu" size={20} /> Mes outils
-            </Badge>
-          </DropdownToggle>
-          <Dropdown.Menu openDirection="left">
-            {PANEL_OPTIONS.map((option) => (
-              <Dropdown.Item
-                key={option.view}
-                onClick={() => onSelectPanel(option.view)}
-              >
-                <LucidIcon name={option.icon as any} size={14} />
-                {option.label}
-                {isAIPanelOpen && activePanelView === option.view && (
-                  <LucidIcon name="Check" size={14} />
-                )}
-              </Dropdown.Item>
-            ))}
-          </Dropdown.Menu>
-        </Dropdown>
-      )}
-      {/* TODO Implement new dropdown in mobile to report a user */}
-      {isMobile ? (
-        <Dropdown>
-          <DropdownToggle>
-            <ActionMenuIconStyled>
-              <LucidIcon name="Ellipsis" size={25} />
-            </ActionMenuIconStyled>
-          </DropdownToggle>
-          <Dropdown.Menu openDirection="left">
-            <Dropdown.Item onClick={onClickReportUser}>Signaler</Dropdown.Item>
-          </Dropdown.Menu>
-        </Dropdown>
-      ) : (
-        <a className="report-link" onClick={onClickReportUser}>
-          Signaler
-        </a>
-      )}
+      <StyledButtonContainer>
+        {canUseAIAssistant && (
+          <Button
+            prependIcon={<LucidIcon name="Sparkles" size={20} />}
+            onClick={() => onSelectPanel('ai')}
+            size="small"
+            variant="secondary"
+          >
+            Assitant {!isMobile && 'Coach'}
+          </Button>
+        )}
+        <ButtonIcon
+          icon={<LucidIcon name="Flag" />}
+          onClick={onClickReportUser}
+          size="small"
+        />
+      </StyledButtonContainer>
     </MessagingConversationHeaderContainer>
   );
 };

--- a/src/use-cases/current-user/current-user.selectors.ts
+++ b/src/use-cases/current-user/current-user.selectors.ts
@@ -1,3 +1,4 @@
+import { FeatureKey } from 'src/api/types';
 import { assertIsDefined } from 'src/utils/asserts';
 import {
   fetchCurrentUserSocialSituationAdapter,
@@ -158,3 +159,11 @@ export const selectFetchCurrentReferrerStatus = (state: RootState) =>
 
 export const selectFetchUserStatsStatus = (state: RootState) =>
   state.currentUser.fetchUserStats.status;
+
+export const selectBetaFeatures = (state: RootState): Record<string, boolean> =>
+  state.currentUser.user?.betaFeatures ?? {};
+
+export const selectHasBetaFeature =
+  (key: FeatureKey) =>
+  (state: RootState): boolean =>
+    selectBetaFeatures(state)[key] === true;


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9150](https://entourage-asso.atlassian.net/browse/EN-9150)
**🚧 PR-Back :** [back/473](https://github.com/ReseauEntourage/entourage-job-back/pull/473)
**💬 Commentaire :**

This pull request introduces support for user beta features, specifically enabling feature-flag-based access to the Messaging AI Assistant. The changes add a `betaFeatures` field to user types, define a `FeatureKey` enum for feature flagging, and update selectors and UI logic to conditionally display the Messaging AI Assistant based on user entitlements.

**Beta feature support:**
* Added a `betaFeatures` field (type `Record<string, boolean>`) to the `User` and `CurrentUserIdentity` types in `src/api/types.ts` to track enabled beta features for each user. [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR312) [[2]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR380)
* Introduced the `FeatureKey` enum in `src/api/types.ts` for type-safe feature flagging, with an initial value for the Messaging AI Assistant.

**Selectors and state management:**
* Added `selectBetaFeatures` and `selectHasBetaFeature` selectors in `src/use-cases/current-user/current-user.selectors.ts` to retrieve beta feature flags and check if a user has a specific feature enabled. [[1]](diffhunk://#diff-a85f6a7eea93162ce4724ebb6cd039608142de9f3f6c2ad010497d7c7a241a2bR1) [[2]](diffhunk://#diff-a85f6a7eea93162ce4724ebb6cd039608142de9f3f6c2ad010497d7c7a241a2bR162-R169)

**Conditional UI logic for Messaging AI Assistant:**
* Updated `MessagingConversation` and `MessagingConversationHeader` components to use the new selectors and only enable the AI Assistant panel if the user has the corresponding beta feature enabled. [[1]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR6-R13) [[2]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR62-R64) [[3]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eL237-R244) [[4]](diffhunk://#diff-628f24f13e14686c4435102bb97956d8c658bc1082c7b60c6b7e815715bb3d04R15-R21) [[5]](diffhunk://#diff-628f24f13e14686c4435102bb97956d8c658bc1082c7b60c6b7e815715bb3d04R57-R68)

These changes lay the groundwork for managing beta feature rollouts and ensure that only eligible users can access new functionality like the Messaging AI Assistant.

[EN-9150]: https://entourage-asso.atlassian.net/browse/EN-9150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ