### PR TITLE
[EN-9174] Add event participation counter for referred candidates

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -440,6 +440,7 @@ export type CurrentUserReferredUser = {
   role: UserRoles;
   email: string;
   coachesContactedCount: number;
+  eventsParticipatedCount: number;
   referredAt: string | null;
   onboardingCompletedAt: string | null;
 };

--- a/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesList.tsx
+++ b/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesList.tsx
@@ -21,6 +21,9 @@ export const RefererCandidatesList = () => {
         coachesContactedCount: `${candidate.coachesContactedCount} coach${
           candidate.coachesContactedCount > 1 ? 's' : ''
         }`,
+        eventsParticipatedCount: `${
+          candidate.eventsParticipatedCount
+        } événement${candidate.eventsParticipatedCount > 1 ? 's' : ''}`,
         referredAt: candidate.referredAt
           ? new Date(candidate.referredAt).toLocaleDateString('fr-FR')
           : '-',

--- a/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.desktop.tsx
+++ b/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.desktop.tsx
@@ -11,6 +11,7 @@ export const RefererCandidatesTableDesktop = ({
         <Th key="candidateName">Candidat</Th>,
         <Th key="candidateEmail">Email</Th>,
         <Th key="coachesContactedCount">Coachs contactés</Th>,
+        <Th key="eventsParticipatedCount">Événements</Th>,
         <Th key="referredAt">Invitation envoyée</Th>,
         <Th key="onboardingCompletedAt">Intégration finalisée le</Th>,
       ]}
@@ -22,6 +23,7 @@ export const RefererCandidatesTableDesktop = ({
           </TdDesktop>
           <TdDesktop>{item.email}</TdDesktop>
           <TdDesktop>{item.coachesContactedCount}</TdDesktop>
+          <TdDesktop>{item.eventsParticipatedCount}</TdDesktop>
           <TdDesktop>{item.referredAt}</TdDesktop>
           <TdDesktop>{item.onboardingCompletedAt}</TdDesktop>
         </TrDesktop>

--- a/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.mobile.tsx
+++ b/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.mobile.tsx
@@ -43,6 +43,15 @@ export const RefererCandidatesTableMobile = ({
 
           <StyledMobileCollaboratorItemField>
             <Text size="large" color="mediumGray">
+              Événements
+            </Text>
+            <Text size="large" weight="bold">
+              {item.eventsParticipatedCount}
+            </Text>
+          </StyledMobileCollaboratorItemField>
+
+          <StyledMobileCollaboratorItemField>
+            <Text size="large" color="mediumGray">
               Invitation envoyée
             </Text>
             <Text size="large">

--- a/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.types.ts
+++ b/src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.types.ts
@@ -3,6 +3,7 @@ export interface RefererCandidatesTableItem {
   name: string;
   email: string;
   coachesContactedCount: string;
+  eventsParticipatedCount: string;
   referredAt: string;
   onboardingCompletedAt: string;
 }


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9174](https://entourage-asso.atlassian.net/browse/EN-9174)
**🚧 PR-Back :** [back/477](https://github.com/ReseauEntourage/entourage-job-back/pull/477)
**💬 Commentaire :**

This pull request adds support for displaying the number of events each referred user has participated in within the backoffice referral candidate lists and tables, both on desktop and mobile. The main changes involve updating the type definitions, adding the new field to the UI, and ensuring the value is correctly formatted and displayed.

**Type and data model updates:**

* Added the `eventsParticipatedCount` field to the `CurrentUserReferredUser` type in `src/api/types.ts` to track the number of events a referred user has participated in.
* Updated the `RefererCandidatesTableItem` interface to include `eventsParticipatedCount` as a string for table display purposes in `src/features/backoffice/referer/RefererCandidatesList/RefererCandidatesTable/RefererCandidatesTable.types.ts`.

**UI updates (Desktop and Mobile):**

* Added a new "Événements" column to the desktop referral candidates table, including both the header and the value cell, in `RefererCandidatesTable.desktop.tsx`. [[1]](diffhunk://#diff-4c881ae886e8855d11ac3a07ce71056f9374f747e1c46fbcbc3c37b2e6af3cccR14) [[2]](diffhunk://#diff-4c881ae886e8855d11ac3a07ce71056f9374f747e1c46fbcbc3c37b2e6af3cccR26)
* Added a new field to display the number of events participated in the mobile referral candidates table in `RefererCandidatesTable.mobile.tsx`.
* Updated the mapping logic in `RefererCandidatesList.tsx` to format and provide the `eventsParticipatedCount` value for display.

[EN-9174]: https://entourage-asso.atlassian.net/browse/EN-9174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ