### PR TITLE
Fix last connection handling in search query

### DIFF
--- a/src/features/backoffice/network-directory/NetworkDirectoryFilters/NetworkDirectoryFilters.tsx
+++ b/src/features/backoffice/network-directory/NetworkDirectoryFilters/NetworkDirectoryFilters.tsx
@@ -155,6 +155,32 @@ export const NetworkDirectoryFilters = () => {
     GA_TAGS.PAGE_ANNUAIRE_SUPPRIMER_FILTRES_CLIC
   );
 
+  const handleSetSearch = useCallback(
+    (updatedSearch?: string) => {
+      const isSearching = !!updatedSearch;
+      const sortOverride =
+        isSearching && sort === NetworkDirectorySort.RELEVANCE
+          ? { sort: NetworkDirectorySort.LAST_CONNECTION }
+          : {};
+
+      push(
+        {
+          pathname: route,
+          query: {
+            ...networkDirectoryQueryParams,
+            ...(updatedSearch
+              ? { search: updatedSearch }
+              : { search: undefined }),
+            ...sortOverride,
+          },
+        },
+        undefined,
+        { shallow: true, scroll: false }
+      );
+    },
+    [networkDirectoryQueryParams, push, sort]
+  );
+
   const filters = useMemo(() => {
     return {
       departments: mutateToArray(departments).map((department) =>
@@ -311,7 +337,7 @@ export const NetworkDirectoryFilters = () => {
             resetFilters();
           }}
           search={search}
-          setSearch={setSearch}
+          setSearch={handleSetSearch}
           setFilters={setFilters}
           placeholder="Rechercher par prénom, nom ou métier"
           additionalButtons={additionalButtons}
@@ -341,6 +367,7 @@ export const NetworkDirectoryFilters = () => {
     selectedEntityNetworkDirectoryFilters,
     filters,
     search,
+    handleSetSearch,
     setSearch,
     setFilters,
     additionalButtons,


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9155](https://entourage-asso.atlassian.net/browse/EN-9155)
**💬 Commentaire :**

This pull request introduces an improvement to the search functionality in the `NetworkDirectoryFilters` component. The main change is the addition of a custom handler for updating the search term, which also manages sorting behavior when a search is performed. This enhances user experience by ensuring that the sorting parameter is appropriately set when searching.

**Enhancements to search and sorting logic:**

* Added a new `handleSetSearch` callback that updates the search term and automatically sets the sort order to `LAST_CONNECTION` when a search is performed, unless the current sort is already by relevance. This ensures more relevant results for users when searching.
* Updated the `setSearch` prop in the `NetworkDirectoryFilters` component to use the new `handleSetSearch` function, integrating the improved search and sorting logic into the component’s UI.
* Included `handleSetSearch` in the component’s dependencies and props to ensure consistent behavior and proper re-rendering when the search handler changes.

[EN-9155]: https://entourage-asso.atlassian.net/browse/EN-9155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ