### PR TITLE
Add CampaignPublic type and update Event with new filter

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,6 @@
 import { CompanyGoal, CompanyUserRole } from '../constants/company';
 import { ContactTypeEnum } from '../constants/contactTypes';
-import { EventMode, EventType } from '../constants/events';
+import { CampaignPublic, EventMode, EventType } from '../constants/events';
 import { Genders } from '../constants/genders';
 import { OnboardingStatus } from '../constants/onboarding';
 import {
@@ -219,6 +219,7 @@ export type Event = {
   audience: string;
   sequences?: string[];
   isParticipating: boolean;
+  publicSensibilise: CampaignPublic[] | null;
 };
 
 export type UserReportDto = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,6 +1,6 @@
 import { CompanyGoal, CompanyUserRole } from '../constants/company';
 import { ContactTypeEnum } from '../constants/contactTypes';
-import { CampaignPublic, EventMode, EventType } from '../constants/events';
+import { PublicSensibilise, EventMode, EventType } from '../constants/events';
 import { Genders } from '../constants/genders';
 import { OnboardingStatus } from '../constants/onboarding';
 import {
@@ -219,7 +219,7 @@ export type Event = {
   audience: string;
   sequences?: string[];
   isParticipating: boolean;
-  publicSensibilise: CampaignPublic[] | null;
+  publicSensibilise: PublicSensibilise[] | null;
 };
 
 export type UserReportDto = {
@@ -723,6 +723,7 @@ export type EventsFilters = {
   modes?: EventMode | EventMode[];
   isParticipating?: boolean;
   includePastEvents?: boolean;
+  publicSensibilise?: string | string[];
 };
 
 export type PostAuthSendVerifyEmailParams = {

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -723,7 +723,7 @@ export type EventsFilters = {
   modes?: EventMode | EventMode[];
   isParticipating?: boolean;
   includePastEvents?: boolean;
-  publicSensibilise?: string | string[];
+  publicSensibilise?: PublicSensibilise | PublicSensibilise[];
 };
 
 export type PostAuthSendVerifyEmailParams = {

--- a/src/components/ui/Badge/Badge.styles.ts
+++ b/src/components/ui/Badge/Badge.styles.ts
@@ -28,6 +28,10 @@ const badgeVariantStyles: Record<BadgeVariant, ReturnType<typeof css>> = {
     background-color: ${COLORS.extraLightAmber};
     color: ${COLORS.amber};
   `,
+  [BadgeVariant.Orange]: css`
+    background-color: ${COLORS.lightOrange};
+    color: ${COLORS.orangeSocial};
+  `,
 };
 
 export const StyledBadge = styled.div<{
@@ -36,6 +40,10 @@ export const StyledBadge = styled.div<{
   $borderRadius?: 'small' | 'medium' | 'large';
   $clickable?: boolean;
 }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
   padding: ${({ $size }) => BADGE_SIZES[$size].padding};
   font-size: ${({ $size }) => BADGE_SIZES[$size].fontSize}px;
@@ -51,5 +59,6 @@ export const StyledBadge = styled.div<{
         return '6px';
     }
   }};
-  ${({ variant }) => badgeVariantStyles[variant]}
+  ${({ variant }) => badgeVariantStyles[variant]};
+  flex-shrink: 0;
 `;

--- a/src/components/ui/Badge/Badge.types.ts
+++ b/src/components/ui/Badge/Badge.types.ts
@@ -5,6 +5,7 @@ export enum BadgeVariant {
   ExtraLightGreen = 'extraLightGreen',
   ExtraLightAmber = 'extraLightAmber',
   ExtraLightPurple = 'extraLightPurple',
+  Orange = 'orange',
 }
 
 export type BadgeSize = 'small' | 'medium' | 'large';

--- a/src/components/ui/Cards/EntityCards/EventCard/EventCard.styles.ts
+++ b/src/components/ui/Cards/EntityCards/EventCard/EventCard.styles.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { COLORS } from '@/src/constants/styles';
 
 export const StyledEventCardPictureContainer = styled.div`
   position: relative;
@@ -12,16 +11,15 @@ export const StyledEventCardPicture = styled.div`
   height: 175px;
 `;
 
-export const StyledEventCardParticipation = styled.div`
+export const StyledEventCardOverlay = styled.div`
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 6px;
   position: absolute;
   top: 10px;
   left: 10px;
-  background-color: ${COLORS.primaryBlue};
-  padding: 4px 8px;
-  border-radius: 20px;
+  width: calc(100% - 20px);
 `;
 
 export const StyledEventCardContentContainer = styled.div`

--- a/src/components/ui/Cards/EntityCards/EventCard/EventCard.tsx
+++ b/src/components/ui/Cards/EntityCards/EventCard/EventCard.tsx
@@ -1,6 +1,12 @@
 import React, { useMemo } from 'react';
-import { LucidIcon, Text } from '@/src/components/ui';
-import { EVENT_IMAGES } from '@/src/constants/events';
+import {
+  Badge,
+  BadgeVariant,
+  LucidIcon,
+  Text,
+  Tooltip,
+} from '@/src/components/ui';
+import { EVENT_IMAGES, PublicSensibilise } from '@/src/constants/events';
 import { EventInfoSummary } from '@/src/features/backoffice/events/EventInfoSummary/EventInfoSummary';
 import { H5 } from '../../../Headings';
 import { LegacyImg } from '../../../Images';
@@ -10,7 +16,7 @@ import { GA_TAGS } from 'src/constants/tags';
 import { gaEvent } from 'src/lib/gtag';
 import {
   StyledEventCardContentContainer,
-  StyledEventCardParticipation,
+  StyledEventCardOverlay,
   StyledEventCardPicture,
   StyledEventCardPictureContainer,
 } from './EventCard.styles';
@@ -26,6 +32,7 @@ export type EventCardProps = Pick<
   | 'fullAddress'
   | 'registrationCount'
   | 'isParticipating'
+  | 'publicSensibilise'
 >;
 
 export function EventCard({
@@ -38,6 +45,7 @@ export function EventCard({
   fullAddress,
   registrationCount,
   isParticipating,
+  publicSensibilise,
 }: EventCardProps) {
   // Compute image based on event type
   const image = useMemo(() => {
@@ -62,12 +70,24 @@ export function EventCard({
         </StyledEventCardPicture>
 
         {/* Participation status */}
-        {isParticipating && (
-          <StyledEventCardParticipation>
-            <LucidIcon name="Check" size={16} color="white" />
-            <Text color="white">Inscrit</Text>
-          </StyledEventCardParticipation>
-        )}
+
+        <StyledEventCardOverlay>
+          {isParticipating && (
+            <Tooltip content="Vous êtes inscrit à cet événement">
+              <Badge variant={BadgeVariant.Primary} borderRadius="large">
+                <LucidIcon name="Check" size={16} color="white" />
+                <Text color="white">Inscrit</Text>
+              </Badge>
+            </Tooltip>
+          )}
+          {publicSensibilise?.includes(PublicSensibilise.YOUNG_PUBLIC) && (
+            <Tooltip content="Événement destiné aux jeunes">
+              <Badge variant={BadgeVariant.Orange} borderRadius="large">
+                100% jeunes
+              </Badge>
+            </Tooltip>
+          )}
+        </StyledEventCardOverlay>
       </StyledEventCardPictureContainer>
       <StyledEventCardContentContainer>
         <H5 title={name} />

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -110,6 +110,5 @@ export const EVENT_TYPES_FILTERS: FilterConstant<string>[] = [
   }),
 ];
 
-export const EVENT_PUBLIC_SENSIBILISE_FILTERS: FilterConstant<PublicSensibilise>[] = [
-  { value: PublicSensibilise.YOUNG_PUBLIC, label: 'Réservé aux jeunes' },
-];
+export const EVENT_PUBLIC_SENSIBILISE_FILTERS: FilterConstant<PublicSensibilise>[] =
+  [{ value: PublicSensibilise.YOUNG_PUBLIC, label: 'Réservé aux jeunes' }];

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -110,6 +110,6 @@ export const EVENT_TYPES_FILTERS: FilterConstant<string>[] = [
   }),
 ];
 
-export const EVENT_PUBLIC_SENSIBILISE_FILTERS: FilterConstant<string>[] = [
+export const EVENT_PUBLIC_SENSIBILISE_FILTERS: FilterConstant<PublicSensibilise>[] = [
   { value: PublicSensibilise.YOUNG_PUBLIC, label: 'Réservé aux jeunes' },
 ];

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -83,6 +83,15 @@ export const EVENT_IMAGES: {
   [EventType.UNKNOWN]: '/static/img/events/placeholder.png',
 };
 
+export enum CampaignPublic {
+  GENERAL_PUBLIC = 'Grand public',
+  COMPANIES = 'Entreprises',
+  ORGANIZATIONS = 'Associations',
+  SCHOLARS = 'Scolaire',
+  AUTHORITIES = 'Collectivité',
+  YOUNG_PUBLIC = 'Jeunes',
+}
+
 export const EVENT_MODES_FILTERS: FilterConstant<EventMode>[] = [
   ...EVENT_MODES.map(({ name, format }) => {
     return {

--- a/src/constants/events.ts
+++ b/src/constants/events.ts
@@ -83,7 +83,7 @@ export const EVENT_IMAGES: {
   [EventType.UNKNOWN]: '/static/img/events/placeholder.png',
 };
 
-export enum CampaignPublic {
+export enum PublicSensibilise {
   GENERAL_PUBLIC = 'Grand public',
   COMPANIES = 'Entreprises',
   ORGANIZATIONS = 'Associations',
@@ -108,4 +108,8 @@ export const EVENT_TYPES_FILTERS: FilterConstant<string>[] = [
       label: name,
     };
   }),
+];
+
+export const EVENT_PUBLIC_SENSIBILISE_FILTERS: FilterConstant<string>[] = [
+  { value: PublicSensibilise.YOUNG_PUBLIC, label: 'Réservé aux jeunes' },
 ];

--- a/src/constants/tags.ts
+++ b/src/constants/tags.ts
@@ -431,6 +431,9 @@ export const GA_TAGS = {
   PAGE_EVENTS_FILTRE_DEPARTMENT_CLIC: {
     action: 'Page_Events_Filtre_Department_Clic',
   },
+  PAGE_EVENTS_FILTRE_PUBLIC_SENSIBILISE_CLIC: {
+    action: 'Page_Events_Filtre_Public_Sensibilise_Clic',
+  },
   PAGE_EVENTS_CARTE_CLIC: {
     action: 'Page_Events_Carte_Clic',
   },

--- a/src/features/backoffice/events/Event/Event.tsx
+++ b/src/features/backoffice/events/Event/Event.tsx
@@ -31,6 +31,7 @@ export const Event = () => {
         fullAddress={selectedEvent.fullAddress}
         registrationCount={selectedEvent.registrationCount}
         isParticipating={selectedEvent.isParticipating}
+        publicSensibilise={selectedEvent.publicSensibilise}
       />
       <Section className="custom-page">
         <StyledBackofficeGrid className={`${isDesktop ? '' : 'mobile'}`}>

--- a/src/features/backoffice/events/EventDirectory/EventDirectory.tsx
+++ b/src/features/backoffice/events/EventDirectory/EventDirectory.tsx
@@ -5,6 +5,7 @@ import { Section } from '@/src/components/ui';
 import {
   EVENT_MODES_FILTERS,
   EVENT_TYPES_FILTERS,
+  EVENT_PUBLIC_SENSIBILISE_FILTERS,
 } from '@/src/constants/events';
 import { GA_TAGS } from '@/src/constants/tags';
 import { Filter, FilterConstant } from '@/src/constants/utils';
@@ -37,7 +38,7 @@ export function EventDirectory() {
     React.useState(false);
 
   // Query params for filters
-  const { modes, search, departmentIds, eventTypes } =
+  const { modes, search, departmentIds, eventTypes, publicSensibilise } =
     useEventDirectoryQueryParams();
 
   // Departments for the department filter
@@ -70,6 +71,12 @@ export function EventDirectory() {
       constants: departmentsIdsFilters,
       title: 'Département',
       tag: GA_TAGS.PAGE_EVENTS_FILTRE_DEPARTMENT_CLIC,
+    } as Filter,
+    {
+      key: 'publicSensibilise',
+      constants: EVENT_PUBLIC_SENSIBILISE_FILTERS,
+      title: 'Thème',
+      tag: GA_TAGS.PAGE_EVENTS_FILTRE_PUBLIC_SENSIBILISE_CLIC,
     } as Filter,
   ];
 
@@ -107,8 +114,17 @@ export function EventDirectory() {
       departmentIds: mutateToArray(departmentIds).map((department) =>
         findConstantFromValue(department, departmentsIdsFilters)
       ),
+      publicSensibilise: mutateToArray(publicSensibilise).map((value) =>
+        findConstantFromValue(value, EVENT_PUBLIC_SENSIBILISE_FILTERS)
+      ),
     };
-  }, [modes, eventTypes, departmentIds, departmentsIdsFilters]);
+  }, [
+    modes,
+    eventTypes,
+    departmentIds,
+    departmentsIdsFilters,
+    publicSensibilise,
+  ]);
 
   // Compute total number of applied filters
   const totalFiltersCount = useMemo(() => {

--- a/src/features/backoffice/events/EventDirectory/useEventDirectoryQueryParams.ts
+++ b/src/features/backoffice/events/EventDirectory/useEventDirectoryQueryParams.ts
@@ -5,12 +5,13 @@ export type EventDirectoryFilters = {
   modes?: string[];
   departmentIds?: string[];
   eventTypes?: string[];
+  publicSensibilise?: string[];
 };
 
 // Get the current query params for the directory filters
 export function useEventDirectoryQueryParams() {
   const {
-    query: { search, modes, eventTypes, departmentIds },
+    query: { search, modes, eventTypes, departmentIds, publicSensibilise },
   } = useRouter();
 
   const normalizeArray = (value: unknown): string[] => {
@@ -27,6 +28,7 @@ export function useEventDirectoryQueryParams() {
     modes: normalizeArray(modes),
     departmentIds: normalizeArray(departmentIds),
     eventTypes: normalizeArray(eventTypes),
+    publicSensibilise: normalizeArray(publicSensibilise),
   };
 
   if (search) {

--- a/src/features/backoffice/events/EventDirectoryList/DirectoryEventItem.tsx
+++ b/src/features/backoffice/events/EventDirectoryList/DirectoryEventItem.tsx
@@ -17,6 +17,7 @@ export function DirectoryEventItem({
   fullAddress,
   registrationCount,
   isParticipating,
+  publicSensibilise,
 }: DirectoryEventItemProps) {
   return (
     <CardListItem dataTestId={salesForceId}>
@@ -30,6 +31,7 @@ export function DirectoryEventItem({
         fullAddress={fullAddress}
         registrationCount={registrationCount}
         isParticipating={isParticipating}
+        publicSensibilise={publicSensibilise}
       />
     </CardListItem>
   );

--- a/src/features/headers/HeaderEvent/HeaderEvent.styles.ts
+++ b/src/features/headers/HeaderEvent/HeaderEvent.styles.ts
@@ -32,3 +32,9 @@ export const StyledHeaderInfoContainer = styled.div`
   flex-direction: column;
   gap: 20px;
 `;
+
+export const StyledTitleAndBadges = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;

--- a/src/features/headers/HeaderEvent/HeaderEvent.tsx
+++ b/src/features/headers/HeaderEvent/HeaderEvent.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Event } from '@/src/api/types';
-import { Section } from '@/src/components/ui';
+import { Badge, BadgeVariant, Section } from '@/src/components/ui';
 import { BackLink } from '@/src/components/ui/BackLink';
 import { H3 } from '@/src/components/ui/Headings';
 import { ImgEvent } from '@/src/components/ui/Images/ImgEvent/ImgEvent';
+import { PublicSensibilise } from '@/src/constants/events';
 import { EventParticipateButton } from '@/src/features/backoffice/events/Event/EventParticipateButton/EventParticipateButton';
 import { EventInfoSummary } from '@/src/features/backoffice/events/EventInfoSummary/EventInfoSummary';
 import { useIsMobile } from '@/src/hooks/utils';
@@ -12,6 +13,7 @@ import {
   StyledHeaderContent,
   StyledHeaderInfoContainer,
   StyledHeaderPictureContainer,
+  StyledTitleAndBadges,
 } from './HeaderEvent.styles';
 
 type HeaderEventProps = Pick<
@@ -25,6 +27,7 @@ type HeaderEventProps = Pick<
   | 'fullAddress'
   | 'registrationCount'
   | 'isParticipating'
+  | 'publicSensibilise'
 >;
 
 const EVENT_PICTURE_SIZE = {
@@ -48,6 +51,7 @@ export const HeaderEvent = ({
   fullAddress,
   registrationCount,
   isParticipating,
+  publicSensibilise,
 }: HeaderEventProps) => {
   const isMobile = useIsMobile();
   const imageSize = EVENT_PICTURE_SIZE[isMobile ? 'mobile' : 'desktop'];
@@ -65,7 +69,17 @@ export const HeaderEvent = ({
             />
           </StyledHeaderPictureContainer>
           <StyledHeaderInfoContainer>
-            <H3 title={name} />
+            <StyledTitleAndBadges>
+              <H3 title={name} />
+              {publicSensibilise?.includes(PublicSensibilise.YOUNG_PUBLIC) && (
+                <Badge
+                  variant={BadgeVariant.ExtraLightPurple}
+                  borderRadius="large"
+                >
+                  100% jeunes
+                </Badge>
+              )}
+            </StyledTitleAndBadges>
             <EventInfoSummary
               startDate={startDate}
               mode={mode}

--- a/src/use-cases/events/events.saga.ts
+++ b/src/use-cases/events/events.saga.ts
@@ -1,5 +1,9 @@
 import { call, put, select, takeLatest, takeLeading } from 'typed-redux-saga';
-import { EventMode, EventType } from '@/src/constants/events';
+import {
+  EventMode,
+  EventType,
+  PublicSensibilise,
+} from '@/src/constants/events';
 import { Api } from 'src/api';
 import { EVENTS_LIMIT } from 'src/constants';
 import { mutateToArray } from 'src/utils';
@@ -66,7 +70,9 @@ function* fetchEventsRequestedSaga(
         departmentIds: mutateToArray(departmentIds),
         modes: mutateToArray(modes) as EventMode[],
         eventTypes: mutateToArray(eventTypes) as EventType[],
-        publicSensibilise: mutateToArray(publicSensibilise),
+        publicSensibilise: mutateToArray(
+          publicSensibilise
+        ) as PublicSensibilise[],
         search,
         offset,
         limit,

--- a/src/use-cases/events/events.saga.ts
+++ b/src/use-cases/events/events.saga.ts
@@ -58,13 +58,15 @@ function* fetchEventsRequestedSaga(
     const offset = yield* select(selectEventsOffset);
     const limit = EVENTS_LIMIT;
 
-    const { departmentIds, search, modes, eventTypes } = action.payload;
+    const { departmentIds, search, modes, eventTypes, publicSensibilise } =
+      action.payload;
 
     const response = yield* call(() =>
       Api.getAllEvents({
         departmentIds: mutateToArray(departmentIds),
         modes: mutateToArray(modes) as EventMode[],
         eventTypes: mutateToArray(eventTypes) as EventType[],
+        publicSensibilise: mutateToArray(publicSensibilise),
         search,
         offset,
         limit,


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9216](https://entourage-asso.atlassian.net/browse/EN-9216) [EN-9217](https://entourage-asso.atlassian.net/browse/EN-9217) [EN-9218](https://entourage-asso.atlassian.net/browse/EN-9218)
**🚧 PR-Back :** [back/485](https://github.com/ReseauEntourage/entourage-job-back/pull/485)
**💬 Commentaire :**

This pull request introduces a new "public sensibilise" (target audience) property for events, with a particular focus on identifying events aimed at young people ("100% jeunes"). The changes span the backend types, API filters, UI badges, and event directory filtering, ensuring that this new property is consistently represented and filterable across the app. Additionally, UI improvements are made to the badge component and event cards for better visual presentation.

**Key changes:**

### Event Model and Filtering

- Added a new `publicSensibilise` property to the `Event` type and integrated it into event filters and API query parameters, allowing filtering and display of events by their target audience (e.g., "Jeunes"). (`src/api/types.ts` [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feL3-R3) [[2]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR222) [[3]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR726); `src/constants/events.ts` [[4]](diffhunk://#diff-4b62f559660e61a04d451f0b40c1aa6c4d283ae67d96d313c76e192e84b68eddR86-R94) [[5]](diffhunk://#diff-4b62f559660e61a04d451f0b40c1aa6c4d283ae67d96d313c76e192e84b68eddR112-R115); `src/features/backoffice/events/EventDirectory/useEventDirectoryQueryParams.ts` [[6]](diffhunk://#diff-af4ed7026e442737e0ef5a9ac28f234f7a688008addbb777668e67bd75344c64R8-R14) [[7]](diffhunk://#diff-af4ed7026e442737e0ef5a9ac28f234f7a688008addbb777668e67bd75344c64R31); `src/use-cases/events/events.saga.ts` [[8]](diffhunk://#diff-6688a94b716c1b9404f1295f48945ee28c0283ffb7a4ecde8299f9534572e7d4L61-R69)

### UI Display for "100% jeunes" Events

- Updated `EventCard` and `HeaderEvent` components to display a "100% jeunes" badge if the event targets young people, using a new orange badge variant for cards and a purple badge for headers. (`src/components/ui/Cards/EntityCards/EventCard/EventCard.tsx` [[1]](diffhunk://#diff-bacfebfbd5be0726fda83890199558ba47dd33c922f3cea8865cdde43b530502L2-R9) [[2]](diffhunk://#diff-bacfebfbd5be0726fda83890199558ba47dd33c922f3cea8865cdde43b530502R35) [[3]](diffhunk://#diff-bacfebfbd5be0726fda83890199558ba47dd33c922f3cea8865cdde43b530502R48) [[4]](diffhunk://#diff-bacfebfbd5be0726fda83890199558ba47dd33c922f3cea8865cdde43b530502R73-R90); `src/features/headers/HeaderEvent/HeaderEvent.tsx` [[5]](diffhunk://#diff-84d07e3ab33522223a9c89d157f8e75fd21c35602833e3c9ec3e9ae7e25d0001L3-R7) [[6]](diffhunk://#diff-84d07e3ab33522223a9c89d157f8e75fd21c35602833e3c9ec3e9ae7e25d0001R16) [[7]](diffhunk://#diff-84d07e3ab33522223a9c89d157f8e75fd21c35602833e3c9ec3e9ae7e25d0001R30) [[8]](diffhunk://#diff-84d07e3ab33522223a9c89d157f8e75fd21c35602833e3c9ec3e9ae7e25d0001R54) [[9]](diffhunk://#diff-84d07e3ab33522223a9c89d157f8e75fd21c35602833e3c9ec3e9ae7e25d0001R72-R82)

### Event Directory Filtering

- Added a new filter ("Thème") to the event directory to allow users to filter events by their `publicSensibilise` value, including analytics tagging for filter usage. (`src/features/backoffice/events/EventDirectory/EventDirectory.tsx` [[1]](diffhunk://#diff-92b064e9ea2f8ac9b283e144b2e0e05f4e3cc76ecc3325852473df16313d1ffcR8) [[2]](diffhunk://#diff-92b064e9ea2f8ac9b283e144b2e0e05f4e3cc76ecc3325852473df16313d1ffcL40-R41) [[3]](diffhunk://#diff-92b064e9ea2f8ac9b283e144b2e0e05f4e3cc76ecc3325852473df16313d1ffcR75-R80) [[4]](diffhunk://#diff-92b064e9ea2f8ac9b283e144b2e0e05f4e3cc76ecc3325852473df16313d1ffcR117-R127); `src/constants/tags.ts` [[5]](diffhunk://#diff-7088ec7ee721cd88882989c258e410ce6e747f7f4191a401cf13bf3ed6c8019cR434-R436)

### Badge Component Enhancements

- Introduced a new orange badge variant and improved badge layout for better alignment and appearance, especially when used in event cards. (`src/components/ui/Badge/Badge.types.ts` [[1]](diffhunk://#diff-9fcea1970c398f937c283a96ed0fb737edbc39058b4b4cf7c27bd2e143b49206R8); `src/components/ui/Badge/Badge.styles.ts` [[2]](diffhunk://#diff-77c432c9939e39b6cb66b718725a427af0a0b319a7b02922bff6b09030db6f3eR31-R34) [[3]](diffhunk://#diff-77c432c9939e39b6cb66b718725a427af0a0b319a7b02922bff6b09030db6f3eR43-R46) [[4]](diffhunk://#diff-77c432c9939e39b6cb66b718725a427af0a0b319a7b02922bff6b09030db6f3eL54-R63)

### UI Refactoring and Consistency

- Refactored event card overlay and participation badge rendering for clearer structure and to accommodate the new badges. (`src/components/ui/Cards/EntityCards/EventCard/EventCard.styles.ts` [[1]](diffhunk://#diff-413c2d87f6b8e5204eefc67855557775d29da4c97aa390338b99f0c96821193dL2) [[2]](diffhunk://#diff-413c2d87f6b8e5204eefc67855557775d29da4c97aa390338b99f0c96821193dL15-R22); `src/features/backoffice/events/Event/Event.tsx` [[3]](diffhunk://#diff-c6d8d9806bc2a45b9bfa6423a76c5e0c390b061f41edcee811a775f89793e469R34); `src/features/backoffice/events/EventDirectoryList/DirectoryEventItem.tsx` [[4]](diffhunk://#diff-982accb244cde4e5630a5faefe78c7c0423bb33e6f041138726ced41826cb388R20) [[5]](diffhunk://#diff-982accb244cde4e5630a5faefe78c7c0423bb33e6f041138726ced41826cb388R34); `src/features/headers/HeaderEvent/HeaderEvent.styles.ts` [[6]](diffhunk://#diff-80f30de238e4680105e34e676505d98a0ff2f08aa1430dc4ce619cd2e899df7bR35-R40)

These changes collectively provide a more informative and filterable event directory, with clear visual cues for events targeting young people and improved badge visuals throughout the UI.

[EN-9216]: https://entourage-asso.atlassian.net/browse/EN-9216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9217]: https://entourage-asso.atlassian.net/browse/EN-9217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-9218]: https://entourage-asso.atlassian.net/browse/EN-9218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ