### PR TITLE
Add conversation type and update messaging logic in slice

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -620,8 +620,14 @@ export type ConversationParticipant = Pick<
 };
 export type ConversationParticipants = ConversationParticipant[];
 
+export enum ConversationType {
+  DIRECT = 'direct',
+  GROUP = 'group',
+}
+
 export type Conversation = {
   id: string;
+  type: ConversationType;
   createdAt?: string;
   updatedAt?: string;
   messages: Message[];

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/ActionList/ActionList.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/ActionList/ActionList.tsx
@@ -39,8 +39,7 @@ export const ActionList = () => {
   const canUseAIAssistant =
     currentUser?.role !== UserRoles.CANDIDATE && hasMessagingAIAssistant;
 
-  const isOneToOneConversation =
-    selectedConversation?.participants.length === 2;
+  const isOneToOneConversation = selectedConversation?.type === 'direct';
   const canShareNetwork =
     isOneToOneConversation && addresee?.role === UserRoles.CANDIDATE;
 

--- a/src/use-cases/messaging/messaging.slice.ts
+++ b/src/use-cases/messaging/messaging.slice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit';
 import { notificationsActions } from '../notifications';
-import { Conversation } from 'src/api/types';
+import { Conversation, ConversationType } from 'src/api/types';
 import { RequestState, SliceRootState } from 'src/store/utils';
 import {
   getSelectedConversationAdapter,
@@ -78,7 +78,7 @@ export const slice = createSlice({
         bindNewConversationSucceeded(state, action) {
           const conversation = state.conversations?.find(
             (conv) =>
-              conv.participants.length === 2 && // Only 1-1 conversations
+              conv.type === 'direct' &&
               conv.participants.find((p) => p.id === action.payload[0].id) // The required user is in the conversation
           );
 
@@ -87,6 +87,10 @@ export const slice = createSlice({
           } else {
             const newConversation: Conversation = {
               id: '',
+              type:
+                action.payload.length > 1
+                  ? ConversationType.GROUP
+                  : ConversationType.DIRECT,
               createdAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
               messages: [],


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9200](https://entourage-asso.atlassian.net/browse/EN-9200)
**🚧 PR-Back :** [back/490](https://github.com/ReseauEntourage/entourage-job-back/pull/490)
**💬 Commentaire :**

This pull request updates the way conversations are classified and handled in the messaging feature by introducing a new `ConversationType` enum and refactoring related logic to use this new type instead of relying on participant counts. This improves code clarity and makes it easier to distinguish between direct (one-to-one) and group conversations throughout the codebase.

**Conversation Type Refactor:**

* Added a new `ConversationType` enum (`DIRECT`, `GROUP`) and updated the `Conversation` type to include a `type` property, allowing explicit differentiation between direct and group conversations.
* Updated the logic in the Redux slice (`messaging.slice.ts`) to use the `type` property instead of checking the number of participants when binding new conversations and when creating new conversations. [[1]](diffhunk://#diff-cba33f6b61f231b7a198b2b4768d3a9bf7ee3b5a549ff36d9a7de91f5d0804b5L81-R81) [[2]](diffhunk://#diff-cba33f6b61f231b7a198b2b4768d3a9bf7ee3b5a549ff36d9a7de91f5d0804b5R90-R93)
* Updated imports in `messaging.slice.ts` to include the new `ConversationType` enum.

**UI Logic Update:**

* Refactored the `ActionList` component to use the new `type` property (`selectedConversation?.type === 'direct'`) instead of checking participant count to determine if a conversation is one-to-one.

[EN-9200]: https://entourage-asso.atlassian.net/browse/EN-9200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ