### PR TITLE
Add AvailabilityTagEditable component and integrate into DashboardProfileCard and HeaderProfile

### DIFF
--- a/src/components/ui/AvailabilityTag/AvailabilityTag.tsx
+++ b/src/components/ui/AvailabilityTag/AvailabilityTag.tsx
@@ -6,13 +6,20 @@ import {
 
 interface AvailabilityTagProps {
   isAvailable: boolean;
+  onClick?: () => void;
 }
 
-export function AvailabilityTag({ isAvailable }: AvailabilityTagProps) {
+export const AvailabilityTag = ({
+  isAvailable,
+  onClick,
+}: AvailabilityTagProps) => {
   return (
-    <StyledAvailabilityTagContainer>
+    <StyledAvailabilityTagContainer
+      onClick={onClick}
+      style={onClick ? { cursor: 'pointer' } : undefined}
+    >
       <StyledAvailabilityTagDot isAvailable={isAvailable} />
       {isAvailable ? 'Disponible' : 'Indisponible'}
     </StyledAvailabilityTagContainer>
   );
-}
+};

--- a/src/components/ui/AvailabilityTag/AvailabilityTagEditable.styles.ts
+++ b/src/components/ui/AvailabilityTag/AvailabilityTagEditable.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const StyledAvailabilityTagEditableContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 220px;
+`;

--- a/src/components/ui/AvailabilityTag/AvailabilityTagEditable.tsx
+++ b/src/components/ui/AvailabilityTag/AvailabilityTagEditable.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Button, Popover, Text } from '@/src/components/ui';
+import { FeedbackModal } from '@/src/features/modals/FeedbackModal/FeedbackModal';
+import { openModal } from '@/src/features/modals/Modal';
+import { useUpdateProfile } from '@/src/hooks/useUpdateProfile';
+import { User } from 'src/api/types';
+import { AvailabilityTag } from './AvailabilityTag';
+import { StyledAvailabilityTagEditableContent } from './AvailabilityTagEditable.styles';
+
+interface AvailabilityTagEditableProps {
+  isAvailable: boolean;
+  user: User;
+}
+
+export const AvailabilityTagEditable = ({
+  isAvailable,
+  user,
+}: AvailabilityTagEditableProps) => {
+  const { updateUserProfile } = useUpdateProfile(user);
+
+  const handleAction = () => {
+    if (isAvailable) {
+      openModal(<FeedbackModal />);
+    } else {
+      updateUserProfile({ isAvailable: true, unavailabilityReason: null });
+    }
+  };
+
+  const label = isAvailable
+    ? 'Vous souhaitez vous rendre indisponible ?'
+    : 'Vous êtes de nouveau disponible ?';
+
+  const buttonLabel = isAvailable
+    ? 'Devenir indisponible'
+    : 'Devenir disponible';
+
+  return (
+    <Popover
+      content={
+        <StyledAvailabilityTagEditableContent>
+          <Text size="small">{label}</Text>
+          <Button size="small" onClick={handleAction}>
+            {buttonLabel}
+          </Button>
+        </StyledAvailabilityTagEditableContent>
+      }
+    >
+      <AvailabilityTag isAvailable={isAvailable} />
+    </Popover>
+  );
+};

--- a/src/components/ui/AvailabilityTag/index.ts
+++ b/src/components/ui/AvailabilityTag/index.ts
@@ -1,1 +1,2 @@
 export * from './AvailabilityTag';
+export * from './AvailabilityTagEditable';

--- a/src/components/ui/Popover/Popover.styles.ts
+++ b/src/components/ui/Popover/Popover.styles.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { COLORS } from 'src/constants/styles';
+
+export type PopoverPlacement = 'top' | 'bottom';
+export type PopoverAlign = 'left' | 'right';
+
+export const StyledPopoverWrapper = styled.div`
+  position: relative;
+  display: inline-flex;
+  cursor: pointer;
+`;
+
+export const StyledPopoverContent = styled.div<{
+  placement: PopoverPlacement;
+  align: PopoverAlign;
+}>`
+  position: absolute;
+  ${({ placement }) =>
+    placement === 'bottom' ? 'top: 100%;' : 'bottom: 100%;'}
+  ${({ align }) => (align === 'right' ? 'right: 0;' : 'left: 0;')}
+  background: ${COLORS.white};
+  border: 1px solid ${COLORS.gray};
+  border-radius: 10px;
+  padding: 12px 14px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  z-index: 100;
+`;

--- a/src/components/ui/Popover/Popover.tsx
+++ b/src/components/ui/Popover/Popover.tsx
@@ -1,0 +1,56 @@
+import React, { useRef, useState } from 'react';
+import {
+  PopoverAlign,
+  PopoverPlacement,
+  StyledPopoverContent,
+  StyledPopoverWrapper,
+} from './Popover.styles';
+
+export type { PopoverPlacement, PopoverAlign };
+
+interface PopoverProps {
+  content: React.ReactNode;
+  children: React.ReactNode;
+  placement?: PopoverPlacement;
+  align?: PopoverAlign;
+}
+
+const CLOSE_DELAY_MS = 150;
+
+export const Popover = ({
+  content,
+  children,
+  placement = 'bottom',
+  align = 'right',
+}: PopoverProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const open = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+    }
+    setIsOpen(true);
+  };
+
+  const scheduleClose = () => {
+    closeTimerRef.current = setTimeout(() => setIsOpen(false), CLOSE_DELAY_MS);
+  };
+
+  return (
+    <StyledPopoverWrapper onMouseEnter={open} onMouseLeave={scheduleClose}>
+      {children}
+      {isOpen && (
+        <StyledPopoverContent
+          placement={placement}
+          align={align}
+          onMouseEnter={open}
+          onMouseLeave={scheduleClose}
+          onClick={() => setIsOpen(false)}
+        >
+          {content}
+        </StyledPopoverContent>
+      )}
+    </StyledPopoverWrapper>
+  );
+};

--- a/src/components/ui/Popover/index.ts
+++ b/src/components/ui/Popover/index.ts
@@ -1,0 +1,1 @@
+export * from './Popover';

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -22,5 +22,6 @@ export * from './Dropdown/Dropdown';
 export * from './Icons';
 export * from './Images';
 export * from './Tooltip';
+export * from './Popover';
 export * from './ProgressBar';
 export * from './CopyInput';

--- a/src/features/backoffice/dashboard/Dashboard.tsx
+++ b/src/features/backoffice/dashboard/Dashboard.tsx
@@ -2,7 +2,6 @@ import React, { useMemo } from 'react';
 import { Section } from '@/src/components/ui';
 import { H1 } from '@/src/components/ui/Headings';
 import { CompanyGoal } from '@/src/constants/company';
-import { UserProfileAvailabilityCard } from '../../profile/ProfilePartCards/UserProfileAvailabilityCard';
 import {
   StyledBackofficeBackground,
   StyledBackofficeGrid,
@@ -59,7 +58,6 @@ export const Dashboard = () => {
         {!isCompanyAdmin && company && (
           <DashboardCompanyCard company={company} />
         )}
-        {isNormalUser && <UserProfileAvailabilityCard centerTitle />}
         <DashboardStaffContactCard />
       </>
     );

--- a/src/features/backoffice/dashboard/DashboardProfileCard/DashboardProfileCard.tsx
+++ b/src/features/backoffice/dashboard/DashboardProfileCard/DashboardProfileCard.tsx
@@ -8,7 +8,7 @@ import {
   TagSize,
   Text,
 } from '@/src/components/ui';
-import { AvailabilityTag } from '@/src/components/ui/AvailabilityTag';
+import { AvailabilityTagEditable } from '@/src/components/ui/AvailabilityTag';
 import { Dot } from '@/src/components/ui/Dot/Dot';
 import { FilePreviewCV } from '@/src/components/ui/Inputs/FileInput/FilePreview';
 import { Skeleton } from '@/src/components/ui/Skeleton/Skeleton';
@@ -80,7 +80,10 @@ export const DashboardProfileCard = () => {
           {organization && <Text>{organization.name}</Text>}
           {userProfile?.department && <Text>{userProfile.department}</Text>}
           <StyledTagList>
-            <AvailabilityTag isAvailable={userProfile?.isAvailable ?? false} />
+            <AvailabilityTagEditable
+              isAvailable={userProfile?.isAvailable ?? false}
+              user={user}
+            />
             {achievements && achievements.length > 0 && (
               <ProfileAchievementHighlighter
                 achievement={achievements[0]}

--- a/src/features/backoffice/parameters/Parameters.tsx
+++ b/src/features/backoffice/parameters/Parameters.tsx
@@ -55,7 +55,25 @@ export const Parameters = () => {
   useConfirmationToaster();
 
   useEffect(() => {
-    const { linkedin } = router.query;
+    const { linkedin, reactivate } = router.query;
+
+    if (reactivate === 'true' && user?.id) {
+      dispatch(
+        currentUserActions.updateProfileRequested({
+          userId: user.id,
+          userProfile: { isAvailable: true, unavailabilityReason: null },
+        })
+      );
+      dispatch(
+        notificationsActions.addNotification({
+          type: 'success',
+          message: 'Votre profil est de nouveau disponible !',
+        })
+      );
+      router.replace('/backoffice/parametres', undefined, { shallow: true });
+      return;
+    }
+
     if (!linkedin) {
       return;
     }

--- a/src/features/headers/HeaderProfile/HeaderProfile.desktop.tsx
+++ b/src/features/headers/HeaderProfile/HeaderProfile.desktop.tsx
@@ -10,7 +10,10 @@ import {
   TagVariant,
   Text,
 } from '@/src/components/ui';
-import { AvailabilityTag } from '@/src/components/ui/AvailabilityTag';
+import {
+  AvailabilityTag,
+  AvailabilityTagEditable,
+} from '@/src/components/ui/AvailabilityTag';
 import { BackLink } from '@/src/components/ui/BackLink';
 import { ImageInput } from '@/src/components/ui/Inputs';
 import { Spinner } from '@/src/components/ui/Spinner';
@@ -147,9 +150,15 @@ export const HeaderProfileDesktop = ({
                     )}
                   </StyledHeaderNameAndRole>
                   <StyledHeaderAvailibilityAndUserActions>
-                    {shouldShowAllProfile && (
-                      <AvailabilityTag isAvailable={isAvailable} />
-                    )}
+                    {shouldShowAllProfile &&
+                      (ownProfile && isEditable ? (
+                        <AvailabilityTagEditable
+                          isAvailable={isAvailable}
+                          user={currentUser}
+                        />
+                      ) : (
+                        <AvailabilityTag isAvailable={isAvailable} />
+                      ))}
                     <UserActions userId={id} userRole={role} />
                   </StyledHeaderAvailibilityAndUserActions>
                 </StyledHeaderProfileNameContainer>

--- a/src/features/headers/HeaderProfile/HeaderProfile.mobile.tsx
+++ b/src/features/headers/HeaderProfile/HeaderProfile.mobile.tsx
@@ -11,7 +11,10 @@ import {
   TagVariant,
   Text,
 } from '@/src/components/ui';
-import { AvailabilityTag } from '@/src/components/ui/AvailabilityTag';
+import {
+  AvailabilityTag,
+  AvailabilityTagEditable,
+} from '@/src/components/ui/AvailabilityTag';
 import { BackLink } from '@/src/components/ui/BackLink';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { ImageInput } from '@/src/components/ui/Inputs';
@@ -22,7 +25,10 @@ import { ProfileAchievementHighlighter } from '../../profile/ProfileAchievementH
 import { ProfileStats } from '../../profile/ProfilePartCards/ProfileStats/ProfileStats';
 import { COLORS } from 'src/constants/styles';
 import { UserRoles } from 'src/constants/users';
-import { selectCurrentUserId } from 'src/use-cases/current-user';
+import {
+  selectAuthenticatedUser,
+  selectCurrentUserId,
+} from 'src/use-cases/current-user';
 import {
   StyledEditPictureIconContainer,
   StyledHeaderAvailibilityAndUserActions,
@@ -74,6 +80,7 @@ export const HeaderProfileMobile = ({
 
   const router = useRouter();
   const currentUserId = useSelector(selectCurrentUserId);
+  const currentUser = useSelector(selectAuthenticatedUser);
   const ownProfile = currentUserId === id;
   const displayMessageButton =
     shouldShowAllProfile && isAvailable && !ownProfile;
@@ -159,9 +166,15 @@ export const HeaderProfileMobile = ({
                 gender={gender}
               />
             )}
-            {shouldShowAllProfile && (
-              <AvailabilityTag isAvailable={isAvailable} />
-            )}
+            {shouldShowAllProfile &&
+              (ownProfile && isEditable ? (
+                <AvailabilityTagEditable
+                  isAvailable={isAvailable}
+                  user={currentUser}
+                />
+              ) : (
+                <AvailabilityTag isAvailable={isAvailable} />
+              ))}
             <UserActions userId={id} userRole={role} openDirection="right" />
           </StyledHeaderAvailibilityAndUserActions>
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9236](https://entourage-asso.atlassian.net/browse/EN-9236)
**🚧 PR-Back :** [back/491](https://github.com/ReseauEntourage/entourage-job-back/pull/491)
**💬 Commentaire :**

This pull request introduces a new editable availability tag component and a reusable popover UI, and updates the user profile and header components to support in-place editing of user availability. The changes enhance the user experience by allowing users to easily toggle their availability status directly from their profile or dashboard, with appropriate UI feedback and modal interactions.

**Key changes:**

### New Components and UI Enhancements

* Added a reusable `Popover` component with customizable placement and alignment, including styles and hover/click behavior for showing content overlays. (`src/components/ui/Popover/Popover.tsx`, `src/components/ui/Popover/Popover.styles.ts`, `src/components/ui/Popover/index.ts`, `src/components/ui/index.ts`) [[1]](diffhunk://#diff-ad7dafecbec2cbc2f064c9859648c294ae3d57a68a1266b7e974c2067d2a4a56R1-R56) [[2]](diffhunk://#diff-1f5eda42e1d6c56741f884f55333979448533982598110e6a3ca8e8360304dceR1-R27) [[3]](diffhunk://#diff-aa6aef4be809665bc8be5d043cd35eab8d952160e0bde10dfd420205faa8c7aaR1) [[4]](diffhunk://#diff-eadb6fcb2aedeca64e3744e1a577995c25f33bb3496cd357ad01681dceb0c587R25)
* Introduced `AvailabilityTagEditable`, a new component that wraps the availability tag in a popover, allowing users to change their availability status or open a feedback modal. Includes supporting styles. (`src/components/ui/AvailabilityTag/AvailabilityTagEditable.tsx`, `src/components/ui/AvailabilityTag/AvailabilityTagEditable.styles.ts`, `src/components/ui/AvailabilityTag/index.ts`) [[1]](diffhunk://#diff-f863c403b1b16723e841533fc2473c8a02887dc78cd82f9173eb1645b4245c49R1-R51) [[2]](diffhunk://#diff-a70faf5dd4c68c74ec1e39834f1ac053a2664dab7ebb8a1b42e1cad05a113eeeR1-R8) [[3]](diffhunk://#diff-8065c5aff77d6f03037fc20d627bef816c7f7abed3e996537e230736d827c99fR2)

### User Profile and Header Integration

* Updated `DashboardProfileCard` and both desktop and mobile versions of `HeaderProfile` to use `AvailabilityTagEditable` for the current user's profile, enabling direct availability editing. Fallbacks to the read-only tag for other users. (`src/features/backoffice/dashboard/DashboardProfileCard/DashboardProfileCard.tsx`, `src/features/headers/HeaderProfile/HeaderProfile.desktop.tsx`, `src/features/headers/HeaderProfile/HeaderProfile.mobile.tsx`) [[1]](diffhunk://#diff-41659062d45fab2405075f2f16083e23b25b5fe4f0dcdde785d3b00f6896dc2aL11-R11) [[2]](diffhunk://#diff-41659062d45fab2405075f2f16083e23b25b5fe4f0dcdde785d3b00f6896dc2aL83-R86) [[3]](diffhunk://#diff-2996284946b900112820a1001c414656fd12a9a33d1123304cd4f9269a441309L13-R16) [[4]](diffhunk://#diff-2996284946b900112820a1001c414656fd12a9a33d1123304cd4f9269a441309L150-R161) [[5]](diffhunk://#diff-f59517f82e8d3a832d1954c76949201c5a3b526608e8c04d14f49c25ce955cd8L14-R17) [[6]](diffhunk://#diff-f59517f82e8d3a832d1954c76949201c5a3b526608e8c04d14f49c25ce955cd8L25-R31) [[7]](diffhunk://#diff-f59517f82e8d3a832d1954c76949201c5a3b526608e8c04d14f49c25ce955cd8R83) [[8]](diffhunk://#diff-f59517f82e8d3a832d1954c76949201c5a3b526608e8c04d14f49c25ce955cd8L162-R177)

### Availability Tag Improvements

* Enhanced `AvailabilityTag` to support an optional `onClick` handler and cursor styling, allowing it to be interactive when needed. (`src/components/ui/AvailabilityTag/AvailabilityTag.tsx`)

### Dashboard and Parameters Logic

* Removed the old availability card from the dashboard for normal users, as the new editable tag replaces its functionality. (`src/features/backoffice/dashboard/Dashboard.tsx`) [[1]](diffhunk://#diff-b3fb91016b7a9b7ab0e4d29f66bacbea33138bb122ed74ac5e57434f58284157L5) [[2]](diffhunk://#diff-b3fb91016b7a9b7ab0e4d29f66bacbea33138bb122ed74ac5e57434f58284157L62)
* Added support for a `reactivate` query parameter in the parameters page, enabling users to reactivate their availability via a URL and receive a notification. (`src/features/backoffice/parameters/Parameters.tsx`)

[EN-9236]: https://entourage-asso.atlassian.net/browse/EN-9236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ