### PR TITLE
Add email error handling and improve form error messages

### DIFF
--- a/src/components/ui/Inputs/Inputs.types.ts
+++ b/src/components/ui/Inputs/Inputs.types.ts
@@ -13,6 +13,7 @@ export interface CommonInputProps<
   onChange: (value: T) => void;
   onBlur?: () => void;
   error?: FieldError;
+  errorContent?: ReactNode;
   disabled?: boolean;
   hidden?: boolean;
   showLabel?: boolean;

--- a/src/components/ui/Inputs/TextInput/TextInput.tsx
+++ b/src/components/ui/Inputs/TextInput/TextInput.tsx
@@ -41,6 +41,7 @@ export function TextInput({
   labelTooltip,
   inputRef,
   error,
+  errorContent,
 }: TextInputProps) {
   const [contextType, setContextType] = useState(type);
   const isPasswordContextType = contextType === 'password';
@@ -107,7 +108,11 @@ export function TextInput({
       </StyledTextInputWrapper>
       {shouldShowFooter && (
         <StyledAnnotations>
-          {error && <StyledAnnotationsErrorMessage error={error} />}
+          {error && (
+            <StyledAnnotationsErrorMessage error={error}>
+              {errorContent}
+            </StyledAnnotationsErrorMessage>
+          )}
           {maxLength && (
             <StyledLimitContainer>
               <StyledLimit>

--- a/src/features/forms/FormSchema/FormSchema.types.ts
+++ b/src/features/forms/FormSchema/FormSchema.types.ts
@@ -1,5 +1,5 @@
 import React, { type JSX } from 'react';
-import { ArrayPath, Path, UseFormGetValues } from 'react-hook-form';
+import { ArrayPath, FieldError, Path, UseFormGetValues } from 'react-hook-form';
 import { RadioTypes } from '@/src/components/ui/Inputs/Radio/Radio.types';
 import { SelectListType } from '@/src/components/ui/Inputs/SelectList';
 import { FilterConstant } from 'src/constants/utils';
@@ -211,6 +211,7 @@ export interface FormFieldTextInput<V extends FormSchemaValidation>
   minLength?: number;
   min?: string;
   max?: string;
+  renderErrorContent?: (error?: FieldError) => React.ReactNode;
 }
 
 export interface FormFieldCheckBox<V extends FormSchemaValidation>

--- a/src/features/forms/FormWithValidation.tsx
+++ b/src/features/forms/FormWithValidation.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import {
   DefaultValues,
+  Path,
   SubmitHandler,
   useForm,
   UseFormWatch,
@@ -35,6 +36,7 @@ export type FormWithValidationRef = {
   resetForm: () => void;
   submit: () => Promise<boolean>;
   watch: UseFormWatch<AnyCantFix>;
+  setFieldError: (name: Path<AnyCantFix>, message: string) => void;
 };
 
 interface FormWithValidationProps<S extends FormSchema<AnyCantFix>> {
@@ -87,11 +89,18 @@ export function FormWithValidation<S extends FormSchema<AnyCantFix>>({
     [fieldOptions]
   );
 
-  const { handleSubmit, control, reset, getValues, resetField, watch } =
-    useForm<ExtractFormSchemaValidation<S>>({
-      defaultValues,
-      shouldUnregister: true,
-    });
+  const {
+    handleSubmit,
+    control,
+    reset,
+    getValues,
+    resetField,
+    watch,
+    setError: setRHFFieldError,
+  } = useForm<ExtractFormSchemaValidation<S>>({
+    defaultValues,
+    shouldUnregister: true,
+  });
 
   useImperativeHandle(innerRef, () => ({
     resetForm: () => reset({} as ExtractFormSchemaValidation<S>),
@@ -108,6 +117,11 @@ export function FormWithValidation<S extends FormSchema<AnyCantFix>>({
         )();
       }),
     watch,
+    setFieldError: (name, message) =>
+      setRHFFieldError(name as Path<ExtractFormSchemaValidation<S>>, {
+        type: 'manual',
+        message,
+      }),
   }));
 
   const onValidForm: SubmitHandler<ExtractFormSchemaValidation<S>> =

--- a/src/features/forms/fields/FieldErrorMessage/FieldErrorMessage.tsx
+++ b/src/features/forms/fields/FieldErrorMessage/FieldErrorMessage.tsx
@@ -1,19 +1,24 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { FieldError } from 'react-hook-form';
 import { StyledErrorMessage } from './FieldErrorMessage.styles';
 
 interface FieldErrorMessageProps {
   error?: FieldError;
   className?: string;
+  children?: ReactNode;
 }
 
 export const FieldErrorMessage = ({
   error,
   className,
+  children,
 }: FieldErrorMessageProps) => {
   return (
     <StyledErrorMessage className={className}>
-      <span>{error?.message ? error.message : ''}</span>
+      <span>
+        {error?.message ? error.message : ''}
+        {children}
+      </span>
     </StyledErrorMessage>
   );
 };

--- a/src/features/forms/fields/GenericField.tsx
+++ b/src/features/forms/fields/GenericField.tsx
@@ -181,6 +181,10 @@ export function GenericField<S extends FormSchema<AnyCantFix>>({
         typeof field.title === 'function' ? field.title(getValue) : field.title,
       value,
       error: showError ? error : undefined,
+      errorContent:
+        showError && isFormFieldTextInput(field) && field.renderErrorContent
+          ? field.renderErrorContent(error)
+          : undefined,
       onChange: onChangeCustom,
       onBlur,
       disabled: field.disable ? field.disable(getValue) : field.disabled,

--- a/src/features/registration/forms/EmailAlreadyUsedHint.tsx
+++ b/src/features/registration/forms/EmailAlreadyUsedHint.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { SimpleLink } from '@/src/components/ui';
+import { ReduxRequestEvents } from '@/src/constants';
+import {
+  createUserSelectors,
+  selectCreateUserError,
+} from '@/src/use-cases/registration';
+
+export function EmailAlreadyUsedInlineLink() {
+  const createUserStatus = useSelector(
+    createUserSelectors.selectCreateUserStatus
+  );
+  const createUserError = useSelector(selectCreateUserError);
+
+  if (
+    createUserStatus !== ReduxRequestEvents.FAILED ||
+    createUserError !== 'DUPLICATE_EMAIL'
+  ) {
+    return null;
+  }
+
+  return (
+    <>
+      {' '}
+      vous pouvez aussi <SimpleLink href="/login">vous connecter</SimpleLink>.
+    </>
+  );
+}

--- a/src/features/registration/forms/formRegistrationAccount.tsx
+++ b/src/features/registration/forms/formRegistrationAccount.tsx
@@ -5,6 +5,7 @@ import { isEmail } from 'validator';
 import { SimpleLink } from '@/src/components/ui';
 import { Genders, GENDERS_FILTERS } from '@/src/constants/genders';
 import { PasswordCriterias } from '@/src/features/backoffice/parameters/ChangePasswordCard/PasswordCriterias';
+import { EmailAlreadyUsedInlineLink } from '@/src/features/registration/forms/EmailAlreadyUsedHint';
 import { FormSchema } from 'src/features/forms/FormSchema';
 
 export const formRegistrationAccount: FormSchema<{
@@ -96,6 +97,8 @@ export const formRegistrationAccount: FormSchema<{
           message: 'Adresse e-mail invalide',
         },
       ],
+      renderErrorContent: (error) =>
+        error?.type === 'manual' ? <EmailAlreadyUsedInlineLink /> : undefined,
     },
     {
       id: 'password',

--- a/src/features/wizard/steps/useWizardStepAccount.tsx
+++ b/src/features/wizard/steps/useWizardStepAccount.tsx
@@ -1,6 +1,7 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Card } from '@/src/components/ui';
+import { ReduxRequestEvents } from '@/src/constants';
 import {
   FormWithValidation,
   FormWithValidationRef,
@@ -10,8 +11,10 @@ import { formRegistrationAccount } from '@/src/features/registration/forms/formR
 import { WizardStep } from '@/src/features/wizard/shell/wizard.types';
 import { useStepFormSubmit } from '@/src/features/wizard/useStepFormSubmit';
 import {
+  createUserSelectors,
   registrationActions,
   selectCompatibleProfilesCount,
+  selectCreateUserError,
   selectRegistrationData,
   selectRegistrationSelectedFlow,
 } from '@/src/use-cases/registration';
@@ -21,7 +24,23 @@ export function useWizardStepAccount() {
   const data = useSelector(selectRegistrationData);
   const selectedFlow = useSelector(selectRegistrationSelectedFlow);
   const compatibleProfilesCount = useSelector(selectCompatibleProfilesCount);
+  const createUserStatus = useSelector(
+    createUserSelectors.selectCreateUserStatus
+  );
+  const createUserError = useSelector(selectCreateUserError);
   const formRef = useRef<FormWithValidationRef>(null);
+
+  useEffect(() => {
+    if (
+      createUserStatus === ReduxRequestEvents.FAILED &&
+      createUserError === 'DUPLICATE_EMAIL'
+    ) {
+      formRef.current?.setFieldError(
+        'email',
+        'Cette adresse email est déjà utilisée,'
+      );
+    }
+  }, [createUserStatus, createUserError]);
 
   // password reste dans state.data (nécessaire à registration.saga.ts pour
   // POST /user/registration) mais ne doit pas repeupler le champ visible du

--- a/src/features/wizard/useRegistrationWizard.ts
+++ b/src/features/wizard/useRegistrationWizard.ts
@@ -164,15 +164,16 @@ export function useRegistrationWizard(): UseRegistrationWizardReturn {
   }, [nextStep, shouldSkipStep, dispatch]);
 
   // Show error notification on failed account creation
+  // (DUPLICATE_EMAIL est affiché inline sous le champ email, voir useWizardStepAccount)
   useEffect(() => {
-    if (createUserStatus === ReduxRequestEvents.FAILED) {
+    if (
+      createUserStatus === ReduxRequestEvents.FAILED &&
+      createUserError !== 'DUPLICATE_EMAIL'
+    ) {
       dispatch(
         notificationsActions.addNotification({
           type: 'danger',
-          message:
-            createUserError === 'DUPLICATE_EMAIL'
-              ? 'Cette adresse email est déjà utilisée'
-              : "Une erreur est survenue lors de l'inscription",
+          message: "Une erreur est survenue lors de l'inscription",
         })
       );
     }


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9418](https://entourage-asso.atlassian.net/browse/EN-9418)
**🚧 PR-Back :** [back/496](https://github.com/ReseauEntourage/entourage-job-back/pull/496)
**💬 Commentaire :**

This pull request introduces an improved, inline error handling experience for email fields during registration, specifically for duplicate email errors. It enhances the form system to allow custom error content rendering, updates the registration flow to display a contextual inline link when an email is already used, and ensures error messages are set and displayed correctly. Additionally, it refines the notification logic to avoid duplicate error messages.

**Form system enhancements:**

* Added an optional `errorContent` prop to `CommonInputProps` and extended the `FieldErrorMessage` component to accept and render children, allowing custom error content in input fields. [[1]](diffhunk://#diff-64ebc3e553083b6b3174f6df45cbe2368ece9d9093d607ea9a506b7d2dc6f066R16) [[2]](diffhunk://#diff-f4879aa6e42481ff5d12e3051e15ca0c5a8f23af84d63c2db4626d879a571c07L1-R21)
* Updated `FormFieldTextInput` to accept a `renderErrorContent` function for rendering custom error content based on the error, and passed this content through `GenericField` to input components. [[1]](diffhunk://#diff-32e6deea8fc7396e0d43fc55bfafa5ad2355a02fe13e8b568fac13b63f82d6bbR214) [[2]](diffhunk://#diff-7d87e3f1c67c1d0e6b3a2bad6667658ab36ce7c5932f517e276f7f14f42e0b9fR184-R187)

**Registration flow improvements:**

* Implemented `EmailAlreadyUsedInlineLink`, a component that renders an inline login link when the duplicate email error occurs, and integrated it into the registration account form via `renderErrorContent`. [[1]](diffhunk://#diff-11be5cf94373018419a7593f9b05e867e91ebfd3d13f4d994d96508da3f5a00fR1-R29) [[2]](diffhunk://#diff-68805f8c37e7dfdfd77b61c5bb386987e951341f53841fbfae3f7e0990a66ffcR8) [[3]](diffhunk://#diff-68805f8c37e7dfdfd77b61c5bb386987e951341f53841fbfae3f7e0990a66ffcR100-R101)
* Enhanced the form handling logic to programmatically set a manual error on the email field when a duplicate email registration attempt fails, ensuring the inline message is shown. [[1]](diffhunk://#diff-8c491a5576c69f928b9b09376b894ea456b08a9bb13cae35ca7af8cf7ba1ec4aR39) [[2]](diffhunk://#diff-8c491a5576c69f928b9b09376b894ea456b08a9bb13cae35ca7af8cf7ba1ec4aL90-R100) [[3]](diffhunk://#diff-8c491a5576c69f928b9b09376b894ea456b08a9bb13cae35ca7af8cf7ba1ec4aR120-R124) [[4]](diffhunk://#diff-98f4d788bf05f1e15240aa0db86b9273a733506b4ab5736ab0abd81f4eb63a91R27-R44)

**Notification logic refinement:**

* Updated the registration wizard to suppress global error notifications for duplicate email errors, as these are now handled inline, preventing redundant messaging.

These changes collectively improve user experience by providing more contextual and actionable feedback directly within the form.

[EN-9418]: https://entourage-asso.atlassian.net/browse/EN-9418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ