### PR TITLE
Improve network directory redirection with default isAvailable filter

### DIFF
--- a/src/features/backoffice/network-directory/hooks/useNetworkDirectoryRedirection.ts
+++ b/src/features/backoffice/network-directory/hooks/useNetworkDirectoryRedirection.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { ContactTypeEnum } from '@/src/constants/contactTypes';
 import { NetworkDirectoryEntity } from '@/src/constants/network-directory';
 import { UserRoles } from '@/src/constants/users';
@@ -12,7 +12,8 @@ const route = '/backoffice/annuaire';
 
 /**
  * Handles the initial redirection to the network directory page with the mandatory
- * `role` and `entity` query params when they are missing from the URL.
+ * `role` and `entity` query params when they are missing from the URL, and defaults
+ * the `isAvailable` filter to checked on first load.
  *
  * On mount, if neither `role` nor `entity` is present in the URL, performs a
  * shallow replace so that:
@@ -24,6 +25,12 @@ const route = '/backoffice/annuaire';
  * - Remote-only users get `contactTypes=REMOTE`.
  * - Physical-only users get `contactTypes=PHYSICAL` and their department pre-selected.
  *
+ * Separately, if `isAvailable` isn't present in the URL the first time this hook
+ * gets to act, it's defaulted to `true`. This only happens once per mount (tracked via
+ * a ref) so that a user unchecking the "available only" filter — which removes
+ * `isAvailable` from the URL rather than setting it to `false` — doesn't get
+ * silently reverted by this effect re-running.
+ *
  * This hook produces no output and is intended to be called once at the page level.
  */
 export function useNetworkDirectoryRedirection() {
@@ -33,6 +40,8 @@ export function useNetworkDirectoryRedirection() {
 
   const role = useRole();
   const entity = useEntity();
+
+  const hasSetDefaultIsAvailable = useRef(false);
 
   useEffect(() => {
     if (!userProfile) {
@@ -53,39 +62,39 @@ export function useNetworkDirectoryRedirection() {
       }
     }
 
-    if (!role && !entity) {
-      if (userRole === UserRoles.CANDIDATE) {
-        replace(
-          {
-            pathname: route,
-            query: {
-              ...query,
-              entity: NetworkDirectoryEntity.USER,
-              role: UserRoles.COACH,
-              contactTypes: contactTypes.length > 0 ? contactTypes : undefined,
-              departments: departments.length > 0 ? departments : undefined,
-            },
-          },
-          undefined,
-          { shallow: true }
-        );
-      } else {
-        replace(
-          {
-            pathname: route,
-            query: {
-              ...query,
-              entity: NetworkDirectoryEntity.USER,
-              role: UserRoles.CANDIDATE,
-              contactTypes: contactTypes.length > 0 ? contactTypes : undefined,
-              departments: departments.length > 0 ? departments : undefined,
-            },
-          },
-          undefined,
-          { shallow: true }
-        );
-      }
+    const needsRoleAndEntityDefaults = !role && !entity;
+    const needsIsAvailableDefault =
+      !hasSetDefaultIsAvailable.current && query.isAvailable === undefined;
+    hasSetDefaultIsAvailable.current = true;
+
+    if (!needsRoleAndEntityDefaults && !needsIsAvailableDefault) {
+      return;
     }
+
+    const roleAndEntityDefaults = needsRoleAndEntityDefaults
+      ? {
+          entity: NetworkDirectoryEntity.USER,
+          role:
+            userRole === UserRoles.CANDIDATE
+              ? UserRoles.COACH
+              : UserRoles.CANDIDATE,
+          contactTypes: contactTypes.length > 0 ? contactTypes : undefined,
+          departments: departments.length > 0 ? departments : undefined,
+        }
+      : {};
+
+    replace(
+      {
+        pathname: route,
+        query: {
+          ...query,
+          ...roleAndEntityDefaults,
+          ...(needsIsAvailableDefault ? { isAvailable: true } : {}),
+        },
+      },
+      undefined,
+      { shallow: true }
+    );
   }, [
     replace,
     role,


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9387](https://entourage-asso.atlassian.net/browse/EN-9387)
**💬 Commentaire :**
This pull request updates the `useNetworkDirectoryRedirection` hook to improve the handling of default query parameters for the network directory page. The main changes ensure that the `isAvailable` filter is set to `true` by default only on the first load, without interfering with user actions, and refactor the logic for setting default `role` and `entity` values.

**Improvements to default query parameter handling:**

* Added logic to default the `isAvailable` filter to `true` only once per mount, using a `useRef` to track if the default has already been set. This prevents the filter from being reset if the user unchecks it later. [[1]](diffhunk://#diff-3ee844aeb82c3121360875f2d334db4bdbf91d7a14efb8a01932cea9547d7e5dR44-R45) [[2]](diffhunk://#diff-3ee844aeb82c3121360875f2d334db4bdbf91d7a14efb8a01932cea9547d7e5dR28-R33)
* Refactored the logic for defaulting the `role` and `entity` query parameters to be more concise and to handle both candidate and non-candidate users in a single code path.
* Updated documentation in the function JSDoc to clarify the new behavior for the `isAvailable` filter and the handling of default parameters. [[1]](diffhunk://#diff-3ee844aeb82c3121360875f2d334db4bdbf91d7a14efb8a01932cea9547d7e5dL15-R16) [[2]](diffhunk://#diff-3ee844aeb82c3121360875f2d334db4bdbf91d7a14efb8a01932cea9547d7e5dR28-R33)

**Code quality and maintainability:**

* Added `useRef` import and removed redundant code branches for improved readability and maintainability.

[EN-9387]: https://entourage-asso.atlassian.net/browse/EN-9387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ