### PR TITLE
Update learning unit behavior (replay) and improve eLearning tests

### DIFF
--- a/cypress/e2e/intercept/journey/formations.req.ts
+++ b/cypress/e2e/intercept/journey/formations.req.ts
@@ -1,0 +1,32 @@
+import { RequestConfig } from './request.types';
+
+/**
+ * Objets représentant des requêtes API pour les tests Cypress de la page Formations.
+ *
+ * Chaque objet contient les détails d'une requête API HTTP, y compris le chemin,
+ * les données de réponse simulées et un alias facultatif pour une utilisation ultérieure dans Cypress.
+ */
+export const formationsJourneyRequests = {
+  GET: [
+    {
+      path: '/elearning/units*',
+      data: { statusCode: 200, body: [] },
+      alias: 'elearningUnits',
+    },
+  ] as RequestConfig[],
+  POST: [
+    {
+      path: '/elearning/units/*/completions',
+      data: {
+        statusCode: 201,
+        body: {
+          id: 'elearning-completion-1',
+          userId: '4d3c885c-4859-4e7b-a428-902812964f08',
+          unitId: 'elearning-unit-1',
+          validatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      alias: 'postElearningCompletion',
+    },
+  ] as RequestConfig[],
+};

--- a/cypress/e2e/intercept/journey/formations.req.ts
+++ b/cypress/e2e/intercept/journey/formations.req.ts
@@ -1,10 +1,10 @@
 import { RequestConfig } from './request.types';
 
 /**
- * Objets représentant des requêtes API pour les tests Cypress de la page Formations.
+ * Objects representing API requests for the Formations page Cypress tests.
  *
- * Chaque objet contient les détails d'une requête API HTTP, y compris le chemin,
- * les données de réponse simulées et un alias facultatif pour une utilisation ultérieure dans Cypress.
+ * Each object contains the details of an HTTP API request, including the path,
+ * the mocked response data, and an optional alias for later use in Cypress.
  */
 export const formationsJourneyRequests = {
   GET: [

--- a/cypress/e2e/intercept/journey/request.types.ts
+++ b/cypress/e2e/intercept/journey/request.types.ts
@@ -1,9 +1,11 @@
 export type RequestConfig = {
   path: string;
-  data: {
-    statusCode?: number;
-    fixture?: string;
-    body?: object;
-  };
+  data:
+    | {
+        statusCode?: number;
+        fixture?: string;
+        body?: object;
+      }
+    | ((req: { url: string; reply: (response: object) => void }) => void);
   alias: string;
 };

--- a/cypress/e2e/intercept/journey/wizard.req.ts
+++ b/cypress/e2e/intercept/journey/wizard.req.ts
@@ -49,4 +49,19 @@ export const wizardJourneyRequests = {
       alias: 'companiesSearch',
     },
   ] as RequestConfig[],
+  POST: [
+    {
+      path: '/elearning/units/*/completions',
+      data: {
+        statusCode: 201,
+        body: {
+          id: 'elearning-completion-1',
+          userId: '4d3c885c-4859-4e7b-a428-902812964f08',
+          unitId: 'elearning-unit-1',
+          validatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      alias: 'postElearningCompletion',
+    },
+  ] as RequestConfig[],
 };

--- a/cypress/e2e/intercept/journey/wizard.req.ts
+++ b/cypress/e2e/intercept/journey/wizard.req.ts
@@ -52,14 +52,18 @@ export const wizardJourneyRequests = {
   POST: [
     {
       path: '/elearning/units/*/completions',
-      data: {
-        statusCode: 201,
-        body: {
-          id: 'elearning-completion-1',
-          userId: '4d3c885c-4859-4e7b-a428-902812964f08',
-          unitId: 'elearning-unit-1',
-          validatedAt: '2026-01-01T00:00:00.000Z',
-        },
+      data: (req) => {
+        const [, unitId] =
+          req.url.match(/\/elearning\/units\/([^/]+)\/completions/) ?? [];
+        req.reply({
+          statusCode: 201,
+          body: {
+            id: 'elearning-completion-1',
+            userId: '4d3c885c-4859-4e7b-a428-902812964f08',
+            unitId,
+            validatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        });
       },
       alias: 'postElearningCompletion',
     },

--- a/cypress/e2e/test/journey/formations-elearning-journey.cy.ts
+++ b/cypress/e2e/test/journey/formations-elearning-journey.cy.ts
@@ -1,0 +1,237 @@
+import { interceptCurrentUserSubResources } from '../../intercept/current-user.req';
+import { formationsJourneyRequests } from '../../intercept/journey/formations.req';
+import bootstrap from '../bootstrap';
+
+describe('Formations', () => {
+  /**
+   * Generate fixtures
+   */
+  bootstrap();
+
+  const currentUserId = '4d3c885c-4859-4e7b-a428-902812964f08';
+
+  const answer = (
+    id: string,
+    label: string,
+    isCorrect: boolean,
+    questionId: string
+  ) => ({ id, questionId, label, isCorrect, explanation: null });
+
+  const question = (id: string, unitId: string, answers: unknown[]) => ({
+    id,
+    unitId,
+    label: `Quelle est la bonne réponse pour ${id} ?`,
+    answers,
+  });
+
+  const unit = ({
+    id,
+    title,
+    questions,
+    completed,
+  }: {
+    id: string;
+    title: string;
+    questions: unknown[];
+    completed?: boolean;
+  }) => ({
+    id,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    title,
+    description: 'Description du module',
+    durationMinutes: 5,
+    videoUrl: `https://www.youtube.com/watch?v=${id}`,
+    questions,
+    roles: [],
+    userCompletions: completed
+      ? [
+          {
+            id: `completion-${id}`,
+            userId: currentUserId,
+            unitId: id,
+            validatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]
+      : [],
+  });
+
+  const interceptElearningUnits = (units: unknown[]) => {
+    cy.intercept('GET', '/elearning/units*', {
+      statusCode: 200,
+      body: units,
+    }).as('elearningUnits');
+  };
+
+  const answerAndConfirm = (answerId: string, nextButtonText: string) => {
+    cy.get(`[data-testid="elearning-quiz-answer-${answerId}"]`).click({
+      force: true,
+    });
+    cy.contains('button', 'Valider').click();
+    cy.contains('button', nextButtonText).click();
+  };
+
+  beforeEach(() => {
+    window.localStorage.setItem('entourage-pro-modal-closed', 'true');
+    window.localStorage.setItem('access-token', '1234');
+
+    formationsJourneyRequests.GET.forEach((request) => {
+      if (request.alias) {
+        cy.intercept('GET', request.path, request.data).as(request.alias);
+      } else {
+        cy.intercept('GET', request.path, request.data);
+      }
+    });
+    formationsJourneyRequests.POST.forEach((request) => {
+      if (request.alias) {
+        cy.intercept('POST', request.path, request.data).as(request.alias);
+      } else {
+        cy.intercept('POST', request.path, request.data);
+      }
+    });
+
+    cy.intercept('GET', '/current', {
+      fixture: 'auth-current-candidate-onboarding-completed-res',
+    }).as('currentIdentity');
+
+    interceptCurrentUserSubResources();
+  });
+
+  describe("Etant donné que je suis un utilisateur authentifié sur la page Formations", () => {
+    it('should complete a not-yet-started module: open it, watch the video, pass the quiz, and see it marked as done', () => {
+      const moduleOne = unit({
+        id: 'elearning-unit-1',
+        title: 'Module Formations 1',
+        questions: [
+          question('formations-question-1', 'elearning-unit-1', [
+            answer(
+              'formations-answer-1-good',
+              'Bonne réponse',
+              true,
+              'formations-question-1'
+            ),
+            answer(
+              'formations-answer-1-bad',
+              'Mauvaise réponse',
+              false,
+              'formations-question-1'
+            ),
+          ]),
+        ],
+      });
+      interceptElearningUnits([moduleOne]);
+
+      cy.visit('/backoffice/ressources/formations');
+      cy.wait('@elearningUnits');
+
+      cy.contains('Module Formations 1')
+        .parents('[class*=StyledElearningUnitCardContainer]')
+        .contains('button', 'Démarrer')
+        .click();
+
+      cy.get('[data-testid="elearning-unit-modal-elearning-unit-1"]').should(
+        'be.visible'
+      );
+      cy.contains('Regardez la vidéo puis passez au quiz');
+
+      cy.contains('button', 'Passer au quiz').click();
+      cy.contains('Quelle est la bonne réponse pour formations-question-1 ?');
+
+      answerAndConfirm('formations-answer-1-good', 'Terminer');
+      cy.wait('@postElearningCompletion');
+
+      cy.get('[data-testid="elearning-unit-modal-elearning-unit-1"]').should(
+        'not.exist'
+      );
+      cy.contains('Module Formations 1')
+        .parents('[class*=StyledElearningUnitCardContainer]')
+        .contains('button', 'Revoir');
+    });
+
+    it('should let the user replay an already-completed module without creating a duplicate completion', () => {
+      const completedUnit = unit({
+        id: 'elearning-unit-1',
+        title: 'Module Formations 1',
+        completed: true,
+        questions: [
+          question('formations-question-1', 'elearning-unit-1', [
+            answer(
+              'formations-answer-1-good',
+              'Bonne réponse',
+              true,
+              'formations-question-1'
+            ),
+            answer(
+              'formations-answer-1-bad',
+              'Mauvaise réponse',
+              false,
+              'formations-question-1'
+            ),
+          ]),
+        ],
+      });
+      interceptElearningUnits([completedUnit]);
+
+      cy.visit('/backoffice/ressources/formations');
+      cy.wait('@elearningUnits');
+
+      cy.contains('Module Formations 1')
+        .parents('[class*=StyledElearningUnitCardContainer]')
+        .contains('button', 'Revoir')
+        .click();
+
+      cy.get('[data-testid="elearning-unit-modal-elearning-unit-1"]').should(
+        'be.visible'
+      );
+
+      cy.contains('button', 'Passer au quiz').click();
+      answerAndConfirm('formations-answer-1-good', 'Terminer');
+      cy.wait('@postElearningCompletion');
+
+      cy.get('[data-testid="elearning-unit-modal-elearning-unit-1"]').should(
+        'not.exist'
+      );
+
+      // Toujours une seule carte pour ce module, toujours marquée "terminé"
+      cy.contains('Module Formations 1')
+        .parents('[class*=StyledElearningUnitCardContainer]')
+        .contains('button', 'Revoir');
+      cy.get('button').contains('Démarrer').should('not.exist');
+    });
+
+    it('should display each module with its own individual status when the user skipped the onboarding eLearning step', () => {
+      cy.fixture('auth-current-candidate-onboarding-completed-res').then(
+        (user) => {
+          cy.intercept('GET', '/current', {
+            statusCode: 200,
+            body: { ...user, elearningCompletedAt: null },
+          }).as('currentIdentity');
+        }
+      );
+
+      const completedUnit = unit({
+        id: 'elearning-unit-1',
+        title: 'Module Formations 1',
+        completed: true,
+        questions: [],
+      });
+      const notCompletedUnit = unit({
+        id: 'elearning-unit-2',
+        title: 'Module Formations 2',
+        questions: [],
+      });
+      interceptElearningUnits([completedUnit, notCompletedUnit]);
+
+      cy.visit('/backoffice/ressources/formations');
+      cy.wait('@elearningUnits');
+
+      cy.contains('Module Formations 1')
+        .parents('[class*=StyledElearningUnitCardContainer]')
+        .contains('button', 'Revoir');
+
+      cy.contains('Module Formations 2')
+        .parents('[class*=StyledElearningUnitCardContainer]')
+        .contains('button', 'Démarrer');
+    });
+  });
+});

--- a/cypress/e2e/test/journey/wizard-journey.cy.ts
+++ b/cypress/e2e/test/journey/wizard-journey.cy.ts
@@ -1021,9 +1021,9 @@ describe('Wizard', () => {
         answerAndConfirm('answer-1b-good', 'Terminer');
         cy.wait('@postElearningCompletion');
 
-        // Enchaînement automatique sur le module suivant, à nouveau verrouillé
-        // (le titre du module n'est pas affiché en texte brut ; la position
-        // "Vidéo 2/2" dans le panneau latéral est le seul indicateur visible)
+        // Automatic transition to the next module, locked again
+        // (the module title is not displayed as plain text; the position
+        // "Vidéo 2/2" in the side panel is the only visible indicator)
         cy.contains('Formation - Vidéo 2/2');
         cy.contains('Regardez la vidéo');
         cy.get('[data-testid^="test-elearning-quiz-question-"]').should(
@@ -1033,10 +1033,10 @@ describe('Wizard', () => {
 
       it('should complete the last module and advance the wizard past the eLearning step', () => {
         interceptElearningUnits([unitTwo]);
-        // L'avancée synchrone vers l'étape "webinar" monte WebinarSelection,
-        // qui appelle /events* immédiatement : sans stub, la requête part avec
-        // le faux token de test et échoue en 401 (erreur non interceptée par
-        // l'app, qui ferait échouer le test).
+        // The synchronous advance to the "webinar" step mounts WebinarSelection,
+        // which calls /events* immediately: without a stub, the request goes out
+        // with the fake test token and fails with a 401 (an error not intercepted
+        // by the app, which would make the test fail).
         cy.intercept('GET', '/events*', { statusCode: 200, body: [] }).as(
           'events'
         );
@@ -1048,7 +1048,7 @@ describe('Wizard', () => {
         answerAndConfirm('answer-2a-good', 'Terminer');
         cy.wait('@postElearningCompletion');
 
-        // Étape suivante : webinaire (dernière étape après l'eLearning pour un candidat)
+        // Next step: webinar (last step after eLearning for a candidate)
         cy.contains('réunion de bienvenue');
       });
     });

--- a/cypress/e2e/test/journey/wizard-journey.cy.ts
+++ b/cypress/e2e/test/journey/wizard-journey.cy.ts
@@ -18,6 +18,16 @@ describe('Wizard', () => {
     });
   };
 
+  const interceptWizardPostRequests = () => {
+    wizardJourneyRequests.POST.forEach((request) => {
+      if (request.alias) {
+        cy.intercept('POST', request.path, request.data).as(request.alias);
+      } else {
+        cy.intercept('POST', request.path, request.data);
+      }
+    });
+  };
+
   const fillAccountForm = (email = 'johndoe@gmail.com') => {
     cy.get('[data-testid="form-registration-account-firstName"]').type('John');
     cy.get('[data-testid="form-registration-account-lastName"]').type('Doe');
@@ -840,6 +850,206 @@ describe('Wizard', () => {
 
         cy.url().should('include', '/backoffice/profile/');
         cy.url().should('not.include', '/backoffice/messaging');
+      });
+    });
+
+    describe("Etant donné que je suis arrivé sur l'étape eLearning du wizard", () => {
+      const answer = (
+        id: string,
+        label: string,
+        isCorrect: boolean,
+        questionId: string
+      ) => ({ id, questionId, label, isCorrect, explanation: null });
+
+      const question = (id: string, unitId: string, answers: unknown[]) => ({
+        id,
+        unitId,
+        label: `Quelle est la bonne réponse pour ${id} ?`,
+        answers,
+      });
+
+      const unit = (id: string, title: string, questions: unknown[]) => ({
+        id,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        title,
+        description: '',
+        durationMinutes: 5,
+        videoUrl: `https://www.youtube.com/watch?v=${id}`,
+        questions,
+        roles: [],
+        userCompletions: [],
+      });
+
+      const unitOne = unit('elearning-unit-1', 'Module 1', [
+        question('question-1a', 'elearning-unit-1', [
+          answer('answer-1a-good', 'Bonne réponse 1', true, 'question-1a'),
+          answer('answer-1a-bad', 'Mauvaise réponse 1', false, 'question-1a'),
+        ]),
+        question('question-1b', 'elearning-unit-1', [
+          answer('answer-1b-good', 'Bonne réponse 2', true, 'question-1b'),
+          answer('answer-1b-bad', 'Mauvaise réponse 2', false, 'question-1b'),
+        ]),
+      ]);
+
+      const unitTwo = unit('elearning-unit-2', 'Module 2', [
+        question('question-2a', 'elearning-unit-2', [
+          answer('answer-2a-good', 'Bonne réponse 3', true, 'question-2a'),
+          answer('answer-2a-bad', 'Mauvaise réponse 3', false, 'question-2a'),
+        ]),
+      ]);
+
+      const interceptElearningUnits = (units: unknown[]) => {
+        cy.intercept('GET', '/elearning/units*', {
+          statusCode: 200,
+          body: units,
+        }).as('elearningUnits');
+      };
+
+      const playVideo = () => {
+        cy.get('.yt-lite .lty-playbtn').click();
+        cy.get('.yt-lite').should('have.class', 'lyt-activated');
+        cy.window().then((win) => {
+          win.dispatchEvent(
+            new MessageEvent('message', {
+              data: JSON.stringify({
+                event: 'onStateChange',
+                info: { playerState: 1 },
+              }),
+              origin: 'https://www.youtube.com',
+            })
+          );
+        });
+      };
+
+      const answerAndConfirm = (answerId: string, nextButtonText: string) => {
+        cy.get(`[data-testid="elearning-quiz-answer-${answerId}"]`).click({
+          force: true,
+        });
+        cy.contains('button', 'Valider').click();
+        cy.contains('button', nextButtonText).click();
+      };
+
+      beforeEach(() => {
+        window.localStorage.setItem('entourage-pro-modal-closed', 'true');
+        window.localStorage.setItem('access-token', '1234');
+
+        interceptWizardGetRequests();
+        interceptWizardPostRequests();
+        interceptCurrentUserSubResources();
+
+        cy.fixture('auth-current-candidate-onboarding-not-started-res').then(
+          (user) => {
+            cy.intercept('GET', '/current', {
+              statusCode: 200,
+              body: {
+                ...user,
+                onboardingStatus: 'in_progress',
+                userSocialSituation: { hasCompletedSurvey: true },
+              },
+            }).as('currentIdentity');
+          }
+        );
+
+        cy.intercept('GET', '/current/profile/complete', {
+          statusCode: 200,
+          body: {
+            id: '00000000-0000-0000-0000-000000000001',
+            hasPicture: true,
+            hasExternalCv: true,
+            description: null,
+            linkedinUrl: null,
+            department: null,
+            isAvailable: true,
+            currentJob: null,
+            optInRecommendations: false,
+            nudges: [],
+            sectorOccupations: [],
+            allowPhysicalEvents: true,
+            allowRemoteEvents: true,
+            experiences: [],
+            formations: [],
+            skills: [],
+            contracts: [],
+            reviews: [],
+            interests: [],
+            customNudges: [],
+            userProfileLanguages: [],
+            hasExtractedCvData: false,
+          },
+        }).as('currentProfileComplete');
+      });
+
+      it('should arrive on the first module locked, with the questionnaire hidden until the video starts', () => {
+        interceptElearningUnits([unitOne, unitTwo]);
+
+        cy.visit('/wizard/run');
+        cy.wait('@elearningUnits');
+
+        cy.contains('Regardez la vidéo');
+        cy.get('[data-testid^="test-elearning-quiz-question-"]').should(
+          'not.exist'
+        );
+      });
+
+      it('should unlock the questionnaire and show the first question once the video starts', () => {
+        interceptElearningUnits([unitOne, unitTwo]);
+
+        cy.visit('/wizard/run');
+        cy.wait('@elearningUnits');
+
+        playVideo();
+
+        cy.contains('Regardez la vidéo').should('not.exist');
+        cy.contains('Question 1 / 2');
+        cy.get(
+          '[data-testid="test-elearning-quiz-question-question-1a"]'
+        ).should('be.visible');
+      });
+
+      it('should progress sequentially through a module questions then move to the next module in a locked state', () => {
+        interceptElearningUnits([unitOne, unitTwo]);
+
+        cy.visit('/wizard/run');
+        cy.wait('@elearningUnits');
+
+        playVideo();
+
+        answerAndConfirm('answer-1a-good', 'Question suivante');
+        cy.contains('Question 2 / 2');
+
+        answerAndConfirm('answer-1b-good', 'Terminer');
+        cy.wait('@postElearningCompletion');
+
+        // Enchaînement automatique sur le module suivant, à nouveau verrouillé
+        // (le titre du module n'est pas affiché en texte brut ; la position
+        // "Vidéo 2/2" dans le panneau latéral est le seul indicateur visible)
+        cy.contains('Formation - Vidéo 2/2');
+        cy.contains('Regardez la vidéo');
+        cy.get('[data-testid^="test-elearning-quiz-question-"]').should(
+          'not.exist'
+        );
+      });
+
+      it('should complete the last module and advance the wizard past the eLearning step', () => {
+        interceptElearningUnits([unitTwo]);
+        // L'avancée synchrone vers l'étape "webinar" monte WebinarSelection,
+        // qui appelle /events* immédiatement : sans stub, la requête part avec
+        // le faux token de test et échoue en 401 (erreur non interceptée par
+        // l'app, qui ferait échouer le test).
+        cy.intercept('GET', '/events*', { statusCode: 200, body: [] }).as(
+          'events'
+        );
+
+        cy.visit('/wizard/run');
+        cy.wait('@elearningUnits');
+
+        playVideo();
+        answerAndConfirm('answer-2a-good', 'Terminer');
+        cy.wait('@postElearningCompletion');
+
+        // Étape suivante : webinaire (dernière étape après l'eLearning pour un candidat)
+        cy.contains('réunion de bienvenue');
       });
     });
   });

--- a/src/features/backoffice/elearning/elearning-unit-card/ElearningUnitCard.tsx
+++ b/src/features/backoffice/elearning/elearning-unit-card/ElearningUnitCard.tsx
@@ -46,18 +46,8 @@ export const ElearningUnitCard = ({
           <Text size="large">
             <LucidIcon name="Clock" /> {elearningUnit.durationMinutes} minutes
           </Text>
-          <Button
-            onClick={start}
-            disabled={isCompleted}
-            prependIcon={
-              isCompleted ? (
-                <LucidIcon name="Check" />
-              ) : (
-                <LucidIcon name="Play" />
-              )
-            }
-          >
-            {!isCompleted ? 'Démarrer' : 'Terminé'}
+          <Button onClick={start} prependIcon={<LucidIcon name="Play" />}>
+            {!isCompleted ? 'Démarrer' : 'Revoir'}
           </Button>
         </StyledElearningUnitCardMetaContainer>
       </StyledElearningUnitCardContainer>

--- a/src/use-cases/elearning/elearning.slice.ts
+++ b/src/use-cases/elearning/elearning.slice.ts
@@ -36,14 +36,20 @@ export const slice = createSlice({
       (state) => state.postElearningCompletion,
       {
         postElearningCompletionSucceeded(state, action) {
-          // Add the new completion to the corresponding elearning unit
+          // Replace (rather than append) so a replay never yields more than
+          // one completion per unit in the store
           const updatedCompletion = action.payload;
           const unitIndex = state.elearningUnits.findIndex(
             (unit) => unit.id === updatedCompletion.unitId
           );
           if (unitIndex !== -1) {
             const unit = state.elearningUnits[unitIndex];
-            unit.userCompletions = [...unit.userCompletions, updatedCompletion];
+            unit.userCompletions = [
+              ...unit.userCompletions.filter(
+                (completion) => completion.unitId !== updatedCompletion.unitId
+              ),
+              updatedCompletion,
+            ];
             state.elearningUnits[unitIndex] = unit;
           }
         },


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9327](https://entourage-asso.atlassian.net/browse/EN-9327)
**🚧 PR-Back :** [back/500](https://github.com/ReseauEntourage/entourage-job-back/pull/500)
**💬 Commentaire :**
This pull request introduces comprehensive improvements to the eLearning module experience, particularly in the Cypress test suite and the eLearning UI. It adds new integration tests for the formations journey, enhances the wizard eLearning step tests, ensures correct handling of module completion (preventing duplicate completions), and updates the UI to better reflect module status. It also refactors request interception for improved test reliability.

**eLearning Cypress Test Enhancements:**

* Added a new test suite `formations-elearning-journey.cy.ts` covering end-to-end scenarios for starting, completing, and replaying eLearning modules in the formations section.
* Expanded wizard eLearning step tests to cover video playback, question progression, module transitions, and completion handling.

**Test Request Handling Improvements:**

* Centralized and standardized API request interception for eLearning journeys by introducing `formationsJourneyRequests` and updating `wizardJourneyRequests` to include POST completions. [[1]](diffhunk://#diff-2de43b65e4feb1e8fe7ed3ca014e01f129b7fced3493a800dd12cf0f32e83e6dR1-R32) [[2]](diffhunk://#diff-b8b414892f7336eb9508af4b70c7ea91cb3a33d79d7b9c81f3edef44facb3920R52-R66)
* Added utility to intercept wizard POST requests for improved test setup consistency.

**eLearning Module Completion Logic:**

* Updated the Redux slice so that when a module is replayed and completed again, any previous completion for that module is replaced (not duplicated) in the store, ensuring only one completion per unit.

**UI/UX Improvements:**

* Changed the `ElearningUnitCard` button label from "Terminé" to "Revoir" for completed modules, and ensured the button is always enabled to allow replaying modules.

[EN-9327]: https://entourage-asso.atlassian.net/browse/EN-9327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ