### PR TITLE
Add eLearning completion timestamp and enhance Alert component

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -610,7 +610,14 @@ export type Message = {
 
 export type ConversationParticipant = Pick<
   User,
-  'id' | 'firstName' | 'lastName' | 'role' | 'gender' | 'zone' | 'email'
+  | 'id'
+  | 'firstName'
+  | 'lastName'
+  | 'role'
+  | 'gender'
+  | 'zone'
+  | 'email'
+  | 'elearningCompletedAt'
 > & {
   userProfile: Pick<UserProfile, 'hasPicture' | 'isAvailable'> | null;
   conversationParticipant: {
@@ -652,6 +659,7 @@ export type PublicProfile = {
   department: DepartmentName;
   currentJob: string;
   description: string;
+  elearningCompletedAt: string | null;
   isAvailable: boolean;
   customNudges: UserProfileNudge[];
   nudges: Nudge[];

--- a/src/components/ui/Alert/Alert.styles.ts
+++ b/src/components/ui/Alert/Alert.styles.ts
@@ -53,6 +53,7 @@ export const StyledAlert = styled.div<{
   $visible: boolean;
   $rounded: boolean;
   $clickable?: boolean;
+  $center: boolean;
 }>`
   display: ${(props) => {
     return props.$visible ? 'flex' : 'none';
@@ -82,6 +83,7 @@ export const StyledAlert = styled.div<{
 
   cursor: ${(props) => (props.$clickable ? 'pointer' : 'default')};
   transition: ${(props) => (props.$clickable ? 'filter 0.2s' : 'none')};
+  justify-content: ${(props) => (props.$center ? 'center' : 'flex-start')};
 
   &:hover {
     filter: ${(props) => (props.$clickable ? 'brightness(0.95)' : 'none')};
@@ -92,9 +94,7 @@ export const StyledAlert = styled.div<{
   }
 `;
 
-export const StyledAlertContainer = styled.div`
-  flex: 1;
-`;
+export const StyledAlertContainer = styled.div``;
 
 export const StyledIconContainer = styled.div<{
   $iconInContainer: boolean;

--- a/src/components/ui/Alert/Alert.styles.ts
+++ b/src/components/ui/Alert/Alert.styles.ts
@@ -53,7 +53,7 @@ export const StyledAlert = styled.div<{
   $visible: boolean;
   $rounded: boolean;
   $clickable?: boolean;
-  $center: boolean;
+  $center?: boolean;
 }>`
   display: ${(props) => {
     return props.$visible ? 'flex' : 'none';
@@ -94,7 +94,24 @@ export const StyledAlert = styled.div<{
   }
 `;
 
-export const StyledAlertContainer = styled.div``;
+export const StyledAlertContainer = styled.div<{
+  $center?: boolean;
+}>`
+  /* Kept at flex: 1 by default so the container fills the row and pushes a
+     closable alert's close button to the far edge. When centering, it must
+     NOT grow — otherwise it eats all the row's free space and the outer
+     row's justify-content: center has nothing left to center against,
+     leaving the icon pinned to the left of a centered text block. */
+  flex: ${(props) => (props.$center ? '0 1 auto' : '1')};
+  ${(props) =>
+    props.$center &&
+    `
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+    `}
+`;
 
 export const StyledIconContainer = styled.div<{
   $iconInContainer: boolean;

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -36,6 +36,7 @@ export const Alert = ({
   title,
   children,
   iconInContainer = false,
+  center = false,
 }: AlertProps) => {
   const handleClick = () => {
     if (clickable && onClick) {
@@ -75,6 +76,7 @@ export const Alert = ({
       $visible={visible}
       $rounded={rounded}
       $clickable={clickable && !!onClick}
+      $center={center}
       onClick={handleClick}
     >
       {resizedIcon && (

--- a/src/components/ui/Alert/Alert.tsx
+++ b/src/components/ui/Alert/Alert.tsx
@@ -85,7 +85,7 @@ export const Alert = ({
         </StyledIconContainer>
       )}
 
-      <StyledAlertContainer>
+      <StyledAlertContainer $center={center}>
         {title && (
           <Text
             weight="semibold"

--- a/src/components/ui/Alert/Alert.types.ts
+++ b/src/components/ui/Alert/Alert.types.ts
@@ -25,4 +25,5 @@ export interface AlertProps {
   clickable?: boolean;
   onClick?: () => void;
   iconInContainer?: boolean;
+  center?: boolean;
 }

--- a/src/components/ui/Tooltip/Tooltip.tsx
+++ b/src/components/ui/Tooltip/Tooltip.tsx
@@ -11,6 +11,12 @@ interface TooltipProps {
   children: React.ReactNode;
   width?: number;
   placement?: TooltipPlacement;
+  /**
+   * Accessible name for icon-only / non-text triggers. When set, the trigger
+   * becomes keyboard-focusable and opens the tooltip on focus, so the
+   * information isn't only reachable by mouse hover.
+   */
+  ariaLabel?: string;
 }
 
 const GAP = 8;
@@ -52,6 +58,7 @@ export const Tooltip = ({
   children,
   width,
   placement = 'bottom',
+  ariaLabel,
 }: TooltipProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [effectivePlacement, setEffectivePlacement] =
@@ -109,6 +116,13 @@ export const Tooltip = ({
       ref={wrapperRef}
       onMouseEnter={handleOpen}
       onMouseLeave={() => setIsOpen(false)}
+      {...(ariaLabel && {
+        tabIndex: 0,
+        role: 'img',
+        'aria-label': ariaLabel,
+        onFocus: handleOpen,
+        onBlur: () => setIsOpen(false),
+      })}
     >
       {children}
       {isOpen &&

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
@@ -64,7 +64,11 @@ export const MessagingConversation = () => {
     'instant' as ScrollBehavior
   );
   const displaySuggestions = useMemo(() => {
-    return selectedConversationId === 'new' && currentUser;
+    return (
+      selectedConversationId === 'new' &&
+      !!currentUser &&
+      currentUser.role !== UserRoles.ADMIN
+    );
   }, [currentUser, selectedConversationId]);
 
   const displayQuickReplies = useMemo(() => {

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.styles.ts
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.styles.ts
@@ -62,6 +62,12 @@ export const ConversationAddresee = styled.div`
   flex-direction: column;
 `;
 
+export const AddreseeBadges = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+`;
+
 export const StyledButtonContainer = styled.div`
   display: flex;
   gap: 15px;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
@@ -1,10 +1,17 @@
 import { useRouter } from 'next/router';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Badge, BadgeVariant, ImgUserProfile, Text } from '@/src/components/ui';
+import {
+  Badge,
+  BadgeVariant,
+  ImgUserProfile,
+  Text,
+  Tooltip,
+} from '@/src/components/ui';
 import { ButtonIcon } from '@/src/components/ui/Button/ButtonIcon';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { COLORS } from '@/src/constants/styles';
+import { UserRoles } from '@/src/constants/users';
 import { openModal } from '@/src/features/modals/Modal';
 import { MessagingConversationReportModal } from '../MessagingConversationReport/MessagingConversationReportModal';
 import {
@@ -12,7 +19,10 @@ import {
   ConversationParticipants,
 } from 'src/api/types';
 import { useIsDesktop, useIsMobile } from 'src/hooks/utils';
-import { selectCurrentUserId } from 'src/use-cases/current-user';
+import {
+  selectCurrentUser,
+  selectCurrentUserId,
+} from 'src/use-cases/current-user';
 import {
   messagingActions,
   selectSelectedConversation,
@@ -20,6 +30,7 @@ import {
 } from 'src/use-cases/messaging';
 import { ActionList } from './ActionList/ActionList';
 import {
+  AddreseeBadges,
   AddreseeInfosContainer,
   AddreseeSection,
   ConversationAddresee,
@@ -36,11 +47,16 @@ export const MessagingConversationHeader = () => {
   const selectedConversationId = useSelector(selectSelectedConversationId);
   const selectedConversation = useSelector(selectSelectedConversation);
   const currentUserId = useSelector(selectCurrentUserId);
+  const currentUser = useSelector(selectCurrentUser);
 
   const addresees = selectedConversation?.participants.filter(
     (participant) => participant.id !== currentUserId
   ) as ConversationParticipants;
   const addresee = addresees ? (addresees[0] as ConversationParticipant) : null;
+  const showAdminExemptionIndicator =
+    currentUser?.role === UserRoles.ADMIN &&
+    !!addresee &&
+    !addresee.elearningCompletedAt;
 
   const onClickBackBtn = () => {
     dispatch(messagingActions.selectConversation(null));
@@ -86,13 +102,26 @@ export const MessagingConversationHeader = () => {
                   <Text weight="bold" size="large">
                     {addresee.firstName} {addresee.lastName}
                   </Text>
-                  <Badge
-                    size="small"
-                    variant={BadgeVariant.HoverBlue}
-                    borderRadius="large"
-                  >
-                    {addresee.role}
-                  </Badge>
+                  <AddreseeBadges>
+                    <Badge
+                      size="small"
+                      variant={BadgeVariant.HoverBlue}
+                      borderRadius="large"
+                    >
+                      {addresee.role}
+                    </Badge>
+                    {showAdminExemptionIndicator && (
+                      <Tooltip content="Formation eLearning non terminée — profil visible uniquement pour vous en tant qu'administrateur Entourage.">
+                        <Badge
+                          size="small"
+                          variant={BadgeVariant.ExtraLightAmber}
+                          borderRadius="large"
+                        >
+                          <LucidIcon name="EyeOff" size={14} />
+                        </Badge>
+                      </Tooltip>
+                    )}
+                  </AddreseeBadges>
                 </ConversationAddresee>
               </AddreseeInfosContainer>
             </AddreseeSection>

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversationHeader/MessagingConversationHeader.tsx
@@ -39,6 +39,9 @@ import {
   MessagingConversationHeaderMainInfos,
 } from './MessagingConversationHeader.styles';
 
+const ADMIN_EXEMPTION_INDICATOR_LABEL =
+  "Formation eLearning non terminée — profil visible uniquement pour vous en tant qu'administrateur Entourage.";
+
 export const MessagingConversationHeader = () => {
   const dispatch = useDispatch();
   const router = useRouter();
@@ -111,7 +114,10 @@ export const MessagingConversationHeader = () => {
                       {addresee.role}
                     </Badge>
                     {showAdminExemptionIndicator && (
-                      <Tooltip content="Formation eLearning non terminée — profil visible uniquement pour vous en tant qu'administrateur Entourage.">
+                      <Tooltip
+                        content={ADMIN_EXEMPTION_INDICATOR_LABEL}
+                        ariaLabel={ADMIN_EXEMPTION_INDICATOR_LABEL}
+                      >
                         <Badge
                           size="small"
                           variant={BadgeVariant.ExtraLightAmber}

--- a/src/features/backoffice/profile/Profile.tsx
+++ b/src/features/backoffice/profile/Profile.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { Section } from '@/src/components/ui';
+import { useSelector } from 'react-redux';
+import { Alert, LucidIcon, Section, Text } from '@/src/components/ui';
+import { AlertType } from '@/src/components/ui/Alert/Alert.types';
 import { UserRoles } from '@/src/constants/users';
 import { ProfileContactPreferences } from '@/src/features/profile/ProfilePartCards/ProfileContactPreferences/ProfileContactPreferences';
 import { ProfileContracts } from '@/src/features/profile/ProfilePartCards/ProfileContracts/ProfileContracts';
@@ -11,6 +13,7 @@ import { ProfileInterests } from '@/src/features/profile/ProfilePartCards/Profil
 import { ProfileLanguages } from '@/src/features/profile/ProfilePartCards/ProfileLanguages/ProfileLanguages';
 import { ProfileNudges } from '@/src/features/profile/ProfilePartCards/ProfileNudges/ProfileNudges';
 import { ProfileProfessionalInformations } from '@/src/features/profile/ProfilePartCards/ProfileProfessionalInformations/ProfileProfessionalInformations';
+import { selectAuthenticatedUser } from '@/src/use-cases/current-user';
 import { ProfileContactCard } from '../../profile/ProfilePartCards/ProfileContactCard';
 import {
   StyledBackofficeBackground,
@@ -28,6 +31,10 @@ import { useSelectSelectedProfile } from './useSelectedProfile';
 export const Profile = () => {
   const isDesktop = useIsDesktop();
   const selectedProfile = useSelectSelectedProfile();
+  const currentUser = useSelector(selectAuthenticatedUser);
+  const showAdminExemptionBanner =
+    currentUser.role === UserRoles.ADMIN &&
+    !selectedProfile.elearningCompletedAt;
   const showProfileExperiences =
     selectedProfile.role === UserRoles.CANDIDATE ||
     (selectedProfile.experiences && selectedProfile.experiences.length > 0);
@@ -55,6 +62,21 @@ export const Profile = () => {
         achievements={selectedProfile.achievements ?? []}
         gender={selectedProfile.gender}
       />
+      {showAdminExemptionBanner && (
+        <Alert
+          type={AlertType.Neutral}
+          variant="outlined"
+          center
+          rounded={false}
+          icon={<LucidIcon name="EyeOff" size={11} />}
+        >
+          <Text size="small">
+            Ce profil n&apos;a pas finalisé son parcours de formation, il vous
+            est présenté à titre indicatif car vous êtes un administrateur
+            Entourage. Il n&apos;est pas visible par les autres utilisateurs.
+          </Text>
+        </Alert>
+      )}
       <Section className="custom-page">
         <StyledBackofficeGrid className={`${isDesktop ? '' : 'mobile'}`}>
           <StyledProfileLeftColumn className={`${isDesktop ? '' : 'mobile'}`}>

--- a/src/hooks/useContactEligibility.spec.tsx
+++ b/src/hooks/useContactEligibility.spec.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 // eslint-disable-next-line import/no-named-as-default
 import expect from 'expect';
 import { useRouter } from 'next/router';
+import { UserRoles } from '@/src/constants/users';
 import { openModal } from '@/src/features/modals/Modal';
 import { useAuthenticatedUser } from '@/src/hooks/authentication/useAuthenticatedUser';
 import { useContactEligibility } from './useContactEligibility';
@@ -51,6 +52,20 @@ describe('useContactEligibility', () => {
       const { result } = renderHook(() => useContactEligibility());
 
       expect(result.current.isEligibleToContact).toBe(false);
+    });
+
+    it('is true for an Admin account, which always has elearningCompletedAt set', () => {
+      // Documents a product assumption (admin-bypass-elearning-gate change):
+      // an Admin account always has `elearningCompletedAt` defined, so this
+      // hook needs no role-specific branch to already be permissive for admins.
+      mockUseAuthenticatedUser.mockReturnValue({
+        role: UserRoles.ADMIN,
+        elearningCompletedAt: '2026-01-01T00:00:00.000Z',
+      });
+
+      const { result } = renderHook(() => useContactEligibility());
+
+      expect(result.current.isEligibleToContact).toBe(true);
     });
   });
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9329](https://entourage-asso.atlassian.net/browse/EN-9329)
**🚧 PR-Back :** [back/501](https://github.com/ReseauEntourage/entourage-job-back/pull/501)
**💬 Commentaire :**

This pull request introduces a new "admin exemption" indicator and banner for user profiles that have not completed their eLearning training, making these profiles visible only to administrators. It also adds support for centering alert content via a new prop, and updates type definitions to track eLearning completion. Additional improvements include minor UI adjustments and expanded test coverage to document product assumptions.

**Admin Exemption Indicator and Banner:**

* Added logic to display an "EyeOff" badge with a tooltip in the messaging conversation header when an admin views a user who hasn't completed eLearning (`MessagingConversationHeader.tsx`, `MessagingConversationHeader.styles.ts`, `Profile.tsx`) [[1]](diffhunk://#diff-628f24f13e14686c4435102bb97956d8c658bc1082c7b60c6b7e815715bb3d04R50-R59) [[2]](diffhunk://#diff-628f24f13e14686c4435102bb97956d8c658bc1082c7b60c6b7e815715bb3d04R105-R124) [[3]](diffhunk://#diff-990396aea458b02254afc107be323204431893fed3c7b54e53d90d7341723e63R65-R70) [[4]](diffhunk://#diff-7bc75903512ace1e499a0dfc4c7e90d340d9cf201a51d2ab529891469955729fR34-R37) [[5]](diffhunk://#diff-7bc75903512ace1e499a0dfc4c7e90d340d9cf201a51d2ab529891469955729fR65-R79).
* Added a visible banner in the profile page for admins viewing such users, clarifying the restricted visibility (`Profile.tsx`).

**Type and Data Model Updates:**

* Extended `ConversationParticipant` and `PublicProfile` types to include `elearningCompletedAt` for tracking training completion (`types.ts`) [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feL613-R620) [[2]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR662).

**UI Enhancements:**

* Added a `center` prop to the `Alert` component to allow content centering, updated styles and props accordingly (`Alert.tsx`, `Alert.types.ts`, `Alert.styles.ts`) [[1]](diffhunk://#diff-3536485eca8071e1a6f6164e3da4ca623e345186aadfbcd75118fa4a936ecda7R39) [[2]](diffhunk://#diff-3536485eca8071e1a6f6164e3da4ca623e345186aadfbcd75118fa4a936ecda7R79) [[3]](diffhunk://#diff-b74b723968fbb3d36d8d61dffda61fbb824edfac10af55778737df6f731f9c95R28) [[4]](diffhunk://#diff-a7b25df9c75fe364bcad93033fd8d53d76043c1632cb39df324dd384e57449b6R56) [[5]](diffhunk://#diff-a7b25df9c75fe364bcad93033fd8d53d76043c1632cb39df324dd384e57449b6R86).
* Minor UI tweaks for alert containers and badge layouts (`Alert.styles.ts`, `MessagingConversationHeader.styles.ts`) [[1]](diffhunk://#diff-a7b25df9c75fe364bcad93033fd8d53d76043c1632cb39df324dd384e57449b6L95-R97) [[2]](diffhunk://#diff-990396aea458b02254afc107be323204431893fed3c7b54e53d90d7341723e63R65-R70).

**Behavioral Adjustments:**

* Updated logic to hide suggestions for admins when starting a new conversation (`MessagingConversation.tsx`).

**Testing and Documentation:**

* Added a test case to document that admin accounts always have `elearningCompletedAt` set, ensuring eligibility logic is consistent (`useContactEligibility.spec.tsx`) [[1]](diffhunk://#diff-e8d97e48f0ff2dce29d2c56f29fd2651958ad8d55aa146ce93f3417c0b3db8d1R5) [[2]](diffhunk://#diff-e8d97e48f0ff2dce29d2c56f29fd2651958ad8d55aa146ce93f3417c0b3db8d1R56-R69).

[EN-9329]: https://entourage-asso.atlassian.net/browse/EN-9329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ