### PR TITLE
Add MessagingWaitingReplyBanner component and selectors

### DIFF
--- a/src/constants/users.ts
+++ b/src/constants/users.ts
@@ -46,6 +46,6 @@ export const USER_ROLES_FILTERS: FilterConstant<UserRoles>[] = [
 export const RELATED_ROLES = {
   [UserRoles.CANDIDATE]: UserRoles.COACH,
   [UserRoles.COACH]: UserRoles.CANDIDATE,
-  [UserRoles.ADMIN]: UserRoles.ADMIN,
+  [UserRoles.ADMIN]: UserRoles.CANDIDATE,
   [UserRoles.REFERER]: UserRoles.CANDIDATE,
 } as const;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { MessagingAIPanel } from '../MessagingAIPanel';
 import { MessagingEmptyState } from '../MessagingEmptyState';
-import { FeatureKey } from 'src/api/types';
+import { ConversationType, FeatureKey } from 'src/api/types';
 import { DELAY_REFRESH_CONVERSATIONS } from 'src/constants';
 import { UserRoles } from 'src/constants/users';
 import { useIsMobile } from 'src/hooks/utils';
@@ -22,6 +22,7 @@ import {
   selectConversationParticipantsAreDeleted,
   selectCurrentUserHasSentMessages,
   selectNewMessage,
+  selectOtherParticipantHasNotReplied,
   selectShouldGiveFeedback,
 } from 'src/use-cases/messaging/messaging.selectors';
 import {
@@ -38,6 +39,7 @@ import { MessagingMessage } from './MessagingMessage/MessagingMessage';
 import { MessagingPinnedInfo } from './MessagingPinnedInfo/MessagingPinnedInfo';
 import { MessagingSuggestions } from './MessagingSuggestions/MessagingSuggestions';
 import { MessagingSuggestionItem } from './MessagingSuggestions/MessagingSuggestions.types';
+import { MessagingWaitingReplyBanner } from './MessagingWaitingReplyBanner/MessagingWaitingReplyBanner';
 
 export const MessagingConversation = () => {
   const dispatch = useDispatch();
@@ -56,6 +58,9 @@ export const MessagingConversation = () => {
   const pinnedInfo = useSelector(selectPinnedInfo);
   const currentUserHasSentMessages = useSelector(
     selectCurrentUserHasSentMessages(currentUserId)
+  );
+  const otherParticipantHasNotReplied = useSelector(
+    selectOtherParticipantHasNotReplied(currentUserId)
   );
   const isAIPanelOpen = useSelector(selectIsAIPanelOpen);
 
@@ -107,6 +112,23 @@ export const MessagingConversation = () => {
     currentUserHasSentMessages,
   ]);
 
+  const displayWaitingReplyBanner = useMemo(() => {
+    if (!selectedConversation || selectedConversationId === 'new') {
+      return false;
+    }
+    if (selectedConversation.id !== selectedConversationId) {
+      return false;
+    }
+    if (selectedConversation.type !== ConversationType.DIRECT) {
+      return false;
+    }
+    return otherParticipantHasNotReplied;
+  }, [
+    selectedConversation,
+    selectedConversationId,
+    otherParticipantHasNotReplied,
+  ]);
+
   const displayFirstContactBanner = useMemo(() => {
     if (!currentUser) {
       return false;
@@ -142,6 +164,12 @@ export const MessagingConversation = () => {
     currentUserHasSentMessages,
     currentUserId,
   ]);
+
+  const otherParticipant = useMemo(() => {
+    return selectedConversation?.participants.find(
+      (p) => p.id !== currentUserId
+    );
+  }, [selectedConversation, currentUserId]);
 
   const reversedMessages = useMemo(() => {
     if (!selectedConversation || !selectedConversation.messages) {
@@ -296,6 +324,13 @@ export const MessagingConversation = () => {
             ) || []
           }
           variant="quick-replies"
+        />
+      )}
+
+      {displayWaitingReplyBanner && currentUser && otherParticipant && (
+        <MessagingWaitingReplyBanner
+          recipientFirstName={otherParticipant.firstName}
+          currentUserRole={currentUser.role as UserRoles}
         />
       )}
 

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
@@ -119,6 +119,9 @@ export const MessagingConversation = () => {
     if (selectedConversation.id !== selectedConversationId) {
       return false;
     }
+    if (conversationParticipantsAreDeleted) {
+      return false;
+    }
     if (selectedConversation.type !== ConversationType.DIRECT) {
       return false;
     }
@@ -126,9 +129,9 @@ export const MessagingConversation = () => {
   }, [
     selectedConversation,
     selectedConversationId,
+    conversationParticipantsAreDeleted,
     otherParticipantHasNotReplied,
   ]);
-
   const displayFirstContactBanner = useMemo(() => {
     if (!currentUser) {
       return false;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.spec.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.spec.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+// eslint-disable-next-line import/no-named-as-default
+import expect from 'expect';
+import React from 'react';
+import '@testing-library/jest-dom';
+import { UserRoles } from '@/src/constants/users';
+import { MessagingWaitingReplyBanner } from './MessagingWaitingReplyBanner';
+
+// The component barrel (@/src/components/ui) transitively imports the
+// ESM-only @react-hook/window-size (cf. useEmailConfirmationPhase.spec.tsx).
+jest.mock('@react-hook/window-size', () => ({
+  useWindowWidth: () => 1280,
+  useWindowSize: () => [1280, 800],
+}));
+
+describe('MessagingWaitingReplyBanner', () => {
+  it("shows the recipient's first name in the title", () => {
+    render(
+      <MessagingWaitingReplyBanner
+        recipientFirstName="Awa"
+        currentUserRole={UserRoles.CANDIDATE}
+      />
+    );
+
+    expect(screen.getByText('Message envoyé à Awa')).toBeInTheDocument();
+  });
+
+  it('shows the waiting-for-reply subtitle', () => {
+    render(
+      <MessagingWaitingReplyBanner
+        recipientFirstName="Awa"
+        currentUserRole={UserRoles.CANDIDATE}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        'Il recevra une notification et vous répondra ici même. En attendant, vous pouvez :'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('always shows a dashboard button linking to /backoffice/dashboard', () => {
+    render(
+      <MessagingWaitingReplyBanner
+        recipientFirstName="Awa"
+        currentUserRole={UserRoles.CANDIDATE}
+      />
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'Voir mon tableau de bord' })
+    ).toHaveAttribute('href', '/backoffice/dashboard');
+  });
+
+  it('shows a "Voir d\'autres coachs" button linking to coaches when the sender is a candidate', () => {
+    render(
+      <MessagingWaitingReplyBanner
+        recipientFirstName="Awa"
+        currentUserRole={UserRoles.CANDIDATE}
+      />
+    );
+
+    expect(
+      screen.getByRole('link', { name: "Voir d'autres coachs" })
+    ).toHaveAttribute(
+      'href',
+      '/backoffice/annuaire?entity=user&sort=relevance&role=Coach'
+    );
+  });
+
+  it('shows a "Voir d\'autres candidats" button linking to candidates when the sender is a coach', () => {
+    render(
+      <MessagingWaitingReplyBanner
+        recipientFirstName="Karim"
+        currentUserRole={UserRoles.COACH}
+      />
+    );
+
+    expect(
+      screen.getByRole('link', { name: "Voir d'autres candidats" })
+    ).toHaveAttribute(
+      'href',
+      '/backoffice/annuaire?entity=user&sort=relevance&role=Candidat'
+    );
+  });
+
+  it('shows a "Voir d\'autres candidats" button when the sender is a referer', () => {
+    render(
+      <MessagingWaitingReplyBanner
+        recipientFirstName="Karim"
+        currentUserRole={UserRoles.REFERER}
+      />
+    );
+
+    expect(
+      screen.getByRole('link', { name: "Voir d'autres candidats" })
+    ).toHaveAttribute(
+      'href',
+      '/backoffice/annuaire?entity=user&sort=relevance&role=Candidat'
+    );
+  });
+});

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.styles.ts
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.styles.ts
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+export const StyledMessagingWaitingReplyBannerContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const StyledMessagingWaitingReplyBannerActions = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+`;

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Button, Text } from '@/src/components/ui';
+import { Alert, Button, ButtonIcon, Text } from '@/src/components/ui';
 import { AlertType } from '@/src/components/ui/Alert/Alert.types';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { COLORS } from '@/src/constants/styles';

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Alert, Button, ButtonIcon, Text } from '@/src/components/ui';
+import { Alert, Button, Text } from '@/src/components/ui';
 import { AlertType } from '@/src/components/ui/Alert/Alert.types';
 import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
 import { COLORS } from '@/src/constants/styles';

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { Alert, Button, ButtonIcon, Text } from '@/src/components/ui';
+import { AlertType } from '@/src/components/ui/Alert/Alert.types';
+import { LucidIcon } from '@/src/components/ui/Icons/LucidIcon';
+import { COLORS } from '@/src/constants/styles';
+import { RELATED_ROLES, UserRoles } from '@/src/constants/users';
+import {
+  StyledMessagingWaitingReplyBannerActions,
+  StyledMessagingWaitingReplyBannerContent,
+} from './MessagingWaitingReplyBanner.styles';
+
+interface MessagingWaitingReplyBannerProps {
+  recipientFirstName: string;
+  currentUserRole: UserRoles;
+}
+
+export const MessagingWaitingReplyBanner = ({
+  recipientFirstName,
+  currentUserRole,
+}: MessagingWaitingReplyBannerProps) => {
+  const oppositeRole = RELATED_ROLES[currentUserRole] || null;
+  const discoverOthersLabel =
+    oppositeRole === UserRoles.COACH
+      ? "Voir d'autres coachs"
+      : "Voir d'autres candidats";
+
+  return (
+    <Alert
+      type={AlertType.Info}
+      variant="outlined"
+      rounded={false}
+      title={`Message envoyé à ${recipientFirstName}`}
+      icon={
+        <ButtonIcon
+          icon={<LucidIcon name="Check" />}
+          color={COLORS.primaryBlue}
+        />
+      }
+    >
+      <StyledMessagingWaitingReplyBannerContent>
+        <Text>
+          Il recevra une notification et vous répondra ici même. En attendant,
+          vous pouvez :
+        </Text>
+        <StyledMessagingWaitingReplyBannerActions>
+          <Button
+            variant="default"
+            size="small"
+            rounded
+            href={`/backoffice/annuaire?entity=user&sort=relevance&role=${oppositeRole}`}
+          >
+            {discoverOthersLabel}
+          </Button>
+          <Button
+            variant="default"
+            size="small"
+            rounded
+            href="/backoffice/dashboard"
+          >
+            Voir mon tableau de bord
+          </Button>
+        </StyledMessagingWaitingReplyBannerActions>
+      </StyledMessagingWaitingReplyBannerContent>
+    </Alert>
+  );
+};

--- a/src/use-cases/messaging/messaging.selectors.spec.ts
+++ b/src/use-cases/messaging/messaging.selectors.spec.ts
@@ -1,0 +1,101 @@
+// eslint-disable-next-line import/no-named-as-default
+import expect from 'expect';
+import { Conversation, ConversationType } from 'src/api/types';
+import { selectOtherParticipantHasNotReplied } from './messaging.selectors';
+import { RootState } from './messaging.slice';
+
+const buildState = (selectedConversation: Conversation | null): RootState =>
+  ({
+    messaging: { selectedConversation },
+  } as unknown as RootState);
+
+const buildMessage = (authorId: string) =>
+  ({
+    id: `msg-${authorId}-${Math.random()}`,
+    authorId,
+  } as Conversation['messages'][number]);
+
+const buildConversation = (overrides: Partial<Conversation>): Conversation =>
+  ({
+    id: 'conversation-1',
+    type: ConversationType.DIRECT,
+    messages: [],
+    participants: [],
+    ...overrides,
+  } as Conversation);
+
+describe('selectOtherParticipantHasNotReplied', () => {
+  const currentUserId = 'user-me';
+  const otherUserId = 'user-other';
+
+  it('is false when there is no selected conversation', () => {
+    const state = buildState(null);
+
+    expect(selectOtherParticipantHasNotReplied(currentUserId)(state)).toBe(
+      false
+    );
+  });
+
+  it('is false when currentUserId is null', () => {
+    const conversation = buildConversation({
+      messages: [buildMessage(currentUserId)],
+    });
+    const state = buildState(conversation);
+
+    expect(selectOtherParticipantHasNotReplied(null)(state)).toBe(false);
+  });
+
+  it('is false for a group conversation, even if only the current user has sent messages', () => {
+    const conversation = buildConversation({
+      type: ConversationType.GROUP,
+      messages: [buildMessage(currentUserId)],
+    });
+    const state = buildState(conversation);
+
+    expect(selectOtherParticipantHasNotReplied(currentUserId)(state)).toBe(
+      false
+    );
+  });
+
+  it('is false when the conversation has no messages yet', () => {
+    const conversation = buildConversation({ messages: [] });
+    const state = buildState(conversation);
+
+    expect(selectOtherParticipantHasNotReplied(currentUserId)(state)).toBe(
+      false
+    );
+  });
+
+  it('is true when every message was sent by the current user', () => {
+    const conversation = buildConversation({
+      messages: [buildMessage(currentUserId), buildMessage(currentUserId)],
+    });
+    const state = buildState(conversation);
+
+    expect(selectOtherParticipantHasNotReplied(currentUserId)(state)).toBe(
+      true
+    );
+  });
+
+  it('is false once the other participant has replied', () => {
+    const conversation = buildConversation({
+      messages: [buildMessage(currentUserId), buildMessage(otherUserId)],
+    });
+    const state = buildState(conversation);
+
+    expect(selectOtherParticipantHasNotReplied(currentUserId)(state)).toBe(
+      false
+    );
+  });
+
+  it('is false when the other participant sent the only message (recipient view)', () => {
+    const conversation = buildConversation({
+      messages: [buildMessage(otherUserId)],
+    });
+    const state = buildState(conversation);
+
+    expect(selectOtherParticipantHasNotReplied(currentUserId)(state)).toBe(
+      false
+    );
+  });
+});

--- a/src/use-cases/messaging/messaging.selectors.ts
+++ b/src/use-cases/messaging/messaging.selectors.ts
@@ -1,4 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit';
+import { ConversationType } from 'src/api/types';
 import { RootState } from './messaging.slice';
 
 export const selectNewMessage = (state: RootState) =>
@@ -77,3 +78,27 @@ export const selectCurrentUserHasSentMessages =
   (currentUserId: string | null) =>
   (state: RootState): boolean =>
     selectCurrentUserHasSentMessagesSelector(state, currentUserId);
+
+const selectOtherParticipantHasNotRepliedSelector = createSelector(
+  [selectSelectedConversation, selectCurrentUserIdParam],
+  (selectedConversation, currentUserId): boolean => {
+    if (!selectedConversation || !currentUserId) {
+      return false;
+    }
+    if (selectedConversation.type !== ConversationType.DIRECT) {
+      return false;
+    }
+    if (selectedConversation.messages.length === 0) {
+      return false;
+    }
+
+    return selectedConversation.messages.every(
+      (message) => message.authorId === currentUserId
+    );
+  }
+);
+
+export const selectOtherParticipantHasNotReplied =
+  (currentUserId: string | null) =>
+  (state: RootState): boolean =>
+    selectOtherParticipantHasNotRepliedSelector(state, currentUserId);


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9405](https://entourage-asso.atlassian.net/browse/EN-9405)
**💬 Commentaire :**

This pull request introduces a new "waiting for reply" banner in the messaging conversation UI, which informs users when the other participant has not yet replied to their direct message. The implementation includes new selectors, UI components, and logic to determine when to display the banner. Additionally, a fix was made to the `RELATED_ROLES` mapping for admin users.

**Messaging conversation UI improvements:**

* Added the `MessagingWaitingReplyBanner` component, which displays an informational banner with actions when the other participant in a direct conversation has not replied. The banner includes buttons to discover other users and to view the dashboard. (`src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.tsx` [[1]](diffhunk://#diff-7599a85df525214039cc65582765bdb567d00ba6c5b40aaac03910dd1c74db17R1-R66) `src/features/backoffice/messaging/MessagingConversation/MessagingWaitingReplyBanner/MessagingWaitingReplyBanner.styles.ts` [[2]](diffhunk://#diff-627edc7f80925da01b5d2dfb7efed274a895da7260c18c4af62dbe7c59e5dc32R1-R13)
* Integrated the new banner into the `MessagingConversation` component, including logic to determine when to show it based on conversation state and participant replies. (`src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx` [[1]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eL5-R5) [[2]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR25) [[3]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR42) [[4]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR62-R64) [[5]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR115-R131) [[6]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR168-R173) [[7]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eR330-R336)

**State management and selectors:**

* Added the `selectOtherParticipantHasNotReplied` selector to determine if the other participant in a direct conversation has not replied to any messages, and wired it into the conversation component. (`src/use-cases/messaging/messaging.selectors.ts` [[1]](diffhunk://#diff-40756e1c6145ab30bf5ea3827c1d9d21814b5800d9162f5138248c8eead492acR2) [[2]](diffhunk://#diff-40756e1c6145ab30bf5ea3827c1d9d21814b5800d9162f5138248c8eead492acR81-R104)

**Constants update:**

* Fixed the `RELATED_ROLES` mapping for `UserRoles.ADMIN` so that admins now see candidates as their related role, aligning with other user roles. (`src/constants/users.ts` [src/constants/users.tsL49-R49](diffhunk://#diff-b919104ae185ee0dbe83245698dadb00136731269bcdd35e98cbe66d49d12319L49-R49))

[EN-9405]: https://entourage-asso.atlassian.net/browse/EN-9405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ