### PR TITLE
Update axios to version 1.18.1 and fix header types in APIHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@react-hook/window-size": "^3.1.1",
     "@reduxjs/toolkit": "^1.9.7",
     "@svgr/webpack": "^8.1.0",
-    "axios": "^0.31.0",
+    "axios": "^1.18.1",
     "check-password-strength": "^2.0.10",
     "dd-trace": "^5.76.0",
     "dompurify": "^3.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       axios:
-        specifier: ^0.31.0
-        version: 0.31.0(debug@4.4.3(supports-color@8.1.1))
+        specifier: ^1.18.1
+        version: 1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       check-password-strength:
         specifier: ^2.0.10
         version: 2.0.10
@@ -2571,6 +2571,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -2737,8 +2741,8 @@ packages:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
 
-  axios@0.31.0:
-    resolution: {integrity: sha512-HGIUj/P74co3rSLBV9SHz9LMgCmrXFEtkfMcC5r6bS5j3dBHUcAje2tS4fmU6WM20kuhvUX04XE58594dpgi1g==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -3910,6 +3914,10 @@ packages:
   http-signature@1.4.0:
     resolution: {integrity: sha512-G5akfn7eKbpDN+8nPS/cb57YeA1jLTVxjpCj7tmm3QKPdyDy7T+qSC40e9ptydSWvkwjSXw1VbkpyEm39ukeAg==}
     engines: {node: '>=0.10'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -5145,8 +5153,9 @@ packages:
   proxy-from-env@1.0.0:
     resolution: {integrity: sha512-F2JHgJQ1iqwnHDcQjVBsq3n/uoaFL+iPW/eAeL7kVxy/2RrWaN4WroKjjvbsoRtv0ftelNyC01bjRhn/bhcf4A==}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -8784,6 +8793,12 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
 
   ajv-formats@2.1.1(ajv@8.18.0):
@@ -8962,13 +8977,15 @@ snapshots:
 
   axe-core@4.10.3: {}
 
-  axios@0.31.0(debug@4.4.3(supports-color@8.1.1)):
+  axios@1.18.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 
@@ -10381,6 +10398,13 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
+    dependencies:
+      agent-base: 6.0.2(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6(supports-color@5.5.0):
     dependencies:
       agent-base: 7.1.4
@@ -11787,7 +11811,7 @@ snapshots:
 
   proxy-from-env@1.0.0: {}
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   prr@1.0.1:
     optional: true

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,6 +1,6 @@
 import axios, {
   AxiosInstance,
-  AxiosRequestHeaders,
+  RawAxiosRequestHeaders,
   AxiosResponse,
 } from 'axios';
 import { DocumentNameType } from '@/src/constants';
@@ -60,7 +60,7 @@ export class APIHandler {
   private get(
     route: string,
     query: object = {},
-    headers: AxiosRequestHeaders = {}
+    headers: RawAxiosRequestHeaders = {}
   ): Promise<AxiosResponse> {
     if (query && typeof query !== 'object') {
       throw new Error(
@@ -73,7 +73,7 @@ export class APIHandler {
   private post<T extends APIRoute>(
     route: Route<T>,
     payload: object,
-    headers?: AxiosRequestHeaders
+    headers?: RawAxiosRequestHeaders
   ): Promise<AxiosResponse> {
     if (payload && typeof payload !== 'object') {
       throw new Error(
@@ -86,7 +86,7 @@ export class APIHandler {
   private put(
     route: string,
     payload?: object,
-    headers?: AxiosRequestHeaders
+    headers?: RawAxiosRequestHeaders
   ): Promise<AxiosResponse> {
     if (payload && typeof payload !== 'object') {
       throw new Error(
@@ -99,7 +99,7 @@ export class APIHandler {
   private patch(
     route: string,
     payload?: object,
-    headers?: AxiosRequestHeaders
+    headers?: RawAxiosRequestHeaders
   ): Promise<AxiosResponse> {
     if (payload && typeof payload !== 'object') {
       throw new Error(
@@ -628,7 +628,7 @@ export class APIHandler {
   /// // //////
 
   getCurrentIdentity(
-    headers: AxiosRequestHeaders | undefined = undefined
+    headers: RawAxiosRequestHeaders | undefined = undefined
   ): Promise<AxiosResponse> {
     return this.get(`/current`, {}, headers);
   }
@@ -638,7 +638,7 @@ export class APIHandler {
   }
 
   getCurrentProfileComplete(
-    headers: AxiosRequestHeaders | undefined = undefined
+    headers: RawAxiosRequestHeaders | undefined = undefined
   ): Promise<AxiosResponse> {
     return this.get(`/current/profile/complete`, {}, headers);
   }
@@ -660,7 +660,7 @@ export class APIHandler {
   }
 
   getCurrentStaffContact(
-    headers: AxiosRequestHeaders | undefined = undefined
+    headers: RawAxiosRequestHeaders | undefined = undefined
   ): Promise<AxiosResponse> {
     return this.get(`/current/staff-contact`, {}, headers);
   }

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -11,7 +11,6 @@ export const addAxiosInterceptors = (api: AxiosInstance): void => {
       if (!isServer && localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)) {
         const accessToken = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN);
         if (accessToken) {
-          // @ts-expect-error after enable TS strict mode. Please, try to fix it
           configModified.headers.authorization = `Bearer ${accessToken}`;
         }
       }


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9313](https://entourage-asso.atlassian.net/browse/EN-9313)
**💬 Commentaire :**

This pull request updates the `axios` dependency to version 1.18.1 and updates the codebase to use the new `RawAxiosRequestHeaders` type, replacing the deprecated `AxiosRequestHeaders`. It also updates related dependencies and lock files for compatibility with the new `axios` version.

**Dependency Upgrades:**

* Upgraded `axios` from version `0.31.0` to `1.18.1` in `package.json` and `pnpm-lock.yaml`, including all references and snapshots. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L46-R46) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL33-R34) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2740-R2745) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8965-R8988)
* Updated transitive dependencies for `axios`, including `https-proxy-agent` (added at version `5.0.1`), `agent-base` (added at version `6.0.2`), and `proxy-from-env` (upgraded to `2.1.0`) for compatibility. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2574-R2577) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3918-R3921) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5148-R5158) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8796-R8801) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10401-R10407) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11790-R11814)

**Code Refactoring for Axios v1:**

* Replaced all instances of `AxiosRequestHeaders` with `RawAxiosRequestHeaders` in `src/api/api.ts` to align with the updated axios types. [[1]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L3-R3) [[2]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L63-R63) [[3]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L76-R76) [[4]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L89-R89) [[5]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L102-R102) [[6]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L631-R631) [[7]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L641-R641) [[8]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542L663-R663)

**Code Cleanup:**

* Removed a TypeScript `@ts-expect-error` comment in `src/api/interceptor.ts` that is no longer necessary after the axios upgrade.

[EN-9313]: https://entourage-asso.atlassian.net/browse/EN-9313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ