### PR TITLE
Add unit tests slices, sagas, and selectors

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -221,6 +221,7 @@ export default defineConfig([
             'tests/**/*',
             '**/__tests__/**',
             '**/__mocks__/**',
+            '**/testUtils/**',
             '**/*{.,_}{test,spec}.{js,jsx,ts,tsx}',
             '**/*.stories.*',
             '**/.storybook/**/*.*',

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,14 @@ const customJestConfig = {
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  // jest-environment-jsdom resolves the "browser" package export condition
+  // by default, which points some packages (e.g. @react-hook/window-size,
+  // @react-hook/debounce) at untranspiled ESM builds Jest can't parse.
+  // Disabling it falls back to the "require"/CJS build for every package.
+  // This only surfaces once a test imports the full use-cases registry
+  // (e.g. the shared Redux test store), which transitively loads UI
+  // components via onboardingOld's saga -> selectors -> utils chain.
+  testEnvironmentOptions: { customExportConditions: [] },
   moduleNameMapper: {},
 };
 

--- a/src/store/testUtils/createTestStore.ts
+++ b/src/store/testUtils/createTestStore.ts
@@ -1,0 +1,113 @@
+import {
+  AnyAction,
+  combineReducers,
+  configureStore,
+  Reducer,
+} from '@reduxjs/toolkit';
+import createSagaMiddleware, { Saga } from 'redux-saga';
+import { all, spawn, call } from 'typed-redux-saga';
+import { useCasesConfig } from '@/src/use-cases';
+import type { RootState as AuthenticationRootState } from '@/src/use-cases/authentication/authentication.slice';
+import type { RootState as CompanyRootState } from '@/src/use-cases/company/company.slice';
+import type { RootState as CurrentUserRootState } from '@/src/use-cases/current-user/current-user.slice';
+import type { RootState as ElearningRootState } from '@/src/use-cases/elearning/elearning.slice';
+import type { RootState as EventsRootState } from '@/src/use-cases/events/events.slice';
+import type { RootState as GamificationRootState } from '@/src/use-cases/gamification/gamification.slice';
+import type { RootState as MessagingRootState } from '@/src/use-cases/messaging/messaging.slice';
+import type { RootState as NotificationsRootState } from '@/src/use-cases/notifications/notifications.slice';
+import type { RootState as OnboardingRootState } from '@/src/use-cases/onboarding/onboarding.slice';
+import type { RootState as OnboardingOldRootState } from '@/src/use-cases/onboardingOld/onboarding.slice';
+import type { RootState as ProfileCompletionRootState } from '@/src/use-cases/profile-completion/profile-completion.slice';
+import type { RootState as ProfilesRootState } from '@/src/use-cases/profiles/profiles.slice';
+import type { RootState as RecruitementAlertsRootState } from '@/src/use-cases/recruitement-alerts/recruitement-alerts.slice';
+import type { RootState as ReferingRootState } from '@/src/use-cases/refering/refering.slice';
+import type { RootState as RegistrationRootState } from '@/src/use-cases/registration/registration.slice';
+import { UseCaseConfigItem } from '@/src/use-cases/types';
+
+const useCasesList = Object.values(useCasesConfig) as UseCaseConfigItem[];
+
+const reducersMap: Record<string, any> = {};
+
+useCasesList.forEach(({ slice }) => {
+  reducersMap[slice.name] = slice.reducer;
+});
+
+// Cast once: `reducersMap` is built dynamically from the runtime use-cases
+// registry (see `TestRootState` comment above for why it can't be typed
+// through `combineReducers`' own inference).
+const reducers = combineReducers(reducersMap) as unknown as Reducer<
+  TestRootState,
+  AnyAction
+>;
+
+// Built from each domain's own (already independently-typed) `RootState`
+// instead of `ReturnType<typeof reducers>`: combining all 15 domains'
+// createSlice-generated types through combineReducers' own generic
+// inference is complex enough that the TypeScript checker silently widens
+// the result to `unknown` (reproduced with a minimal repro, not specific to
+// this codebase). Intersecting the pre-resolved per-domain types sidesteps
+// that entirely.
+export type TestRootState = AuthenticationRootState &
+  CompanyRootState &
+  CurrentUserRootState &
+  ElearningRootState &
+  EventsRootState &
+  GamificationRootState &
+  MessagingRootState &
+  NotificationsRootState &
+  OnboardingRootState &
+  OnboardingOldRootState &
+  ProfileCompletionRootState &
+  ProfilesRootState &
+  RecruitementAlertsRootState &
+  ReferingRootState &
+  RegistrationRootState;
+
+function createRootSaga(dispatch: (action: AnyAction) => void) {
+  return function* rootSaga() {
+    yield* all(
+      useCasesList
+        .filter(
+          (useCase): useCase is UseCaseConfigItem & { saga: Saga } =>
+            !!useCase.saga
+        )
+        .map((useCase) =>
+          spawn(function* () {
+            try {
+              yield* call(useCase.saga);
+            } catch (error) {
+              dispatch({
+                type: 'SAGA_ERROR',
+                error: error?.toString?.(),
+                useCaseName: useCase.slice.name,
+              });
+            }
+          })
+        )
+    );
+  };
+}
+
+/**
+ * Builds a real store from the same use-case reducer/saga registry as the
+ * production store (`src/store/store.ts`), so behavioral tests exercise the
+ * actual saga -> reducer -> selector chain instead of a mocked one.
+ */
+export function createTestStore(preloadedState?: Partial<TestRootState>) {
+  const sagaMiddleware = createSagaMiddleware();
+
+  const store = configureStore({
+    reducer: reducers,
+    preloadedState,
+    middleware: (getDefaultMiddleware) => [
+      ...getDefaultMiddleware({ thunk: true, serializableCheck: false }),
+      sagaMiddleware,
+    ],
+  });
+
+  sagaMiddleware.run(createRootSaga(store.dispatch));
+
+  return store;
+}
+
+export type TestStore = ReturnType<typeof createTestStore>;

--- a/src/store/testUtils/flushPromises.ts
+++ b/src/store/testUtils/flushPromises.ts
@@ -1,0 +1,9 @@
+/**
+ * Waits a macrotask tick so that pending saga effects (API calls awaited via
+ * `call`, and the `put`s that follow) have settled before assertions run.
+ */
+export function flushPromises() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}

--- a/src/store/testUtils/mockApi.ts
+++ b/src/store/testUtils/mockApi.ts
@@ -1,0 +1,12 @@
+import { Api } from '@/src/api';
+
+/**
+ * Typed accessor for the auto-mocked `Api` singleton (`jest.mock('@/src/api')`
+ * auto-mocks every instance method). Callers must still call
+ * `jest.mock('@/src/api')` themselves at the top of their spec file so Jest
+ * can hoist it; this only removes the repeated `Api.x as jest.Mock` casts.
+ */
+export function getMockedApi() {
+  // eslint-disable-next-line no-undef -- `jest` global is only declared for *.spec.ts files by this repo's eslint config; this helper is imported from within those files at runtime.
+  return jest.mocked(Api);
+}

--- a/src/store/testUtils/renderWithProviders.tsx
+++ b/src/store/testUtils/renderWithProviders.tsx
@@ -1,0 +1,32 @@
+import { render, RenderOptions } from '@testing-library/react';
+import { ReactElement, ReactNode } from 'react';
+import { Provider } from 'react-redux';
+import { createTestStore, TestRootState, TestStore } from './createTestStore';
+
+interface RenderWithProvidersOptions extends Omit<RenderOptions, 'wrapper'> {
+  preloadedState?: Partial<TestRootState>;
+  store?: TestStore;
+}
+
+/**
+ * Renders a component wrapped in a real Redux `<Provider>`, backed by the
+ * shared test store, so `useSelector`/`useDispatch` exercise real store
+ * wiring instead of a mocked `react-redux` module.
+ */
+export function renderWithProviders(
+  ui: ReactElement,
+  {
+    preloadedState,
+    store = createTestStore(preloadedState),
+    ...renderOptions
+  }: RenderWithProvidersOptions = {}
+) {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  }
+
+  return {
+    store,
+    ...render(ui, { wrapper: Wrapper, ...renderOptions }),
+  };
+}

--- a/src/store/testUtils/seedAccessToken.ts
+++ b/src/store/testUtils/seedAccessToken.ts
@@ -1,0 +1,14 @@
+import { STORAGE_KEYS } from '@/src/constants';
+
+/**
+ * Seeds `localStorage` with an access token before creating a test store.
+ * `authentication`'s saga reads the token from `localStorage` via a
+ * `fork(initSaga)` at startup (not from preloaded state) and dispatches
+ * `setAccessToken`, overwriting any `authentication.accessToken` passed as
+ * preloaded state. Domains whose sagas guard on `selectAccessToken` (e.g.
+ * `current-user`) need this instead of preloaded state to simulate being
+ * logged in.
+ */
+export function seedAccessToken(token: string) {
+  localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, token);
+}

--- a/src/store/utils/createRequestAdapter/createRequestAdapter.spec.ts
+++ b/src/store/utils/createRequestAdapter/createRequestAdapter.spec.ts
@@ -12,16 +12,18 @@ describe('createRequestAdapter', () => {
       {
         token: string;
       },
-      void
+      { reason: string }
     >();
 
     interface State {
       token: string | null;
+      error: string | null;
       login: RequestState<typeof loginRequestAdapter>;
     }
 
     const initialState: State = {
       token: null,
+      error: null,
       login: loginRequestAdapter.getInitialState(),
     };
 
@@ -32,6 +34,9 @@ describe('createRequestAdapter', () => {
         ...loginRequestAdapter.getReducers<State>((state) => state.login, {
           loginUserSucceeded(state, action) {
             state.token = action.payload.token;
+          },
+          loginUserFailed(state, action) {
+            state.error = action.payload.reason;
           },
         }),
       },
@@ -130,16 +135,19 @@ describe('createRequestAdapter', () => {
 
   it(`
     Given initial state
-    When user dispatches failed action
+    When user dispatches failed action with a reason
     Then status should be FAILED
       And isIdle should be false
       And isRequested should be false
       And isSucceeded should be false
       And isFailed should be true
+      Then error into state should equal to the dispatched reason
   `, () => {
     const { selectors, authentication, store } = getSlice();
 
-    store.dispatch(authentication.actions.loginUserFailed());
+    store.dispatch(
+      authentication.actions.loginUserFailed({ reason: 'invalid credentials' })
+    );
 
     expect(selectors.selectLoginUserStatus(store.getState())).toBe(
       ReduxRequestEvents.FAILED
@@ -148,6 +156,7 @@ describe('createRequestAdapter', () => {
     expect(selectors.selectIsLoginUserRequested(store.getState())).toBe(false);
     expect(selectors.selectIsLoginUserSucceeded(store.getState())).toBe(false);
     expect(selectors.selectIsLoginUserFailed(store.getState())).toBe(true);
+    expect(store.getState().authentication.error).toBe('invalid credentials');
   });
 
   it(`
@@ -174,5 +183,39 @@ describe('createRequestAdapter', () => {
     expect(selectors.selectIsLoginUserRequested(store.getState())).toBe(false);
     expect(selectors.selectIsLoginUserSucceeded(store.getState())).toBe(false);
     expect(selectors.selectIsLoginUserFailed(store.getState())).toBe(false);
+  });
+
+  it(`
+    Given a store with a succeeded request
+    When user dispatches reset action
+    Then status should be IDLE again
+  `, () => {
+    const { selectors, authentication, store } = getSlice();
+
+    store.dispatch(authentication.actions.loginUserSucceeded({ token: 'x' }));
+    store.dispatch(authentication.actions.loginUserReset());
+
+    expect(selectors.selectLoginUserStatus(store.getState())).toBe(
+      ReduxRequestEvents.IDLE
+    );
+    expect(selectors.selectIsLoginUserIdle(store.getState())).toBe(true);
+  });
+
+  it(`
+    Given a store with a failed request
+    When user dispatches reset action
+    Then status should be IDLE again
+  `, () => {
+    const { selectors, authentication, store } = getSlice();
+
+    store.dispatch(
+      authentication.actions.loginUserFailed({ reason: 'network error' })
+    );
+    store.dispatch(authentication.actions.loginUserReset());
+
+    expect(selectors.selectLoginUserStatus(store.getState())).toBe(
+      ReduxRequestEvents.IDLE
+    );
+    expect(selectors.selectIsLoginUserIdle(store.getState())).toBe(true);
   });
 });

--- a/src/use-cases/authentication/authentication.saga.spec.ts
+++ b/src/use-cases/authentication/authentication.saga.spec.ts
@@ -1,0 +1,320 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { STORAGE_KEYS } from '@/src/constants';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
+import { slice } from './authentication.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+function buildAxiosError(status: number, message?: string) {
+  return {
+    isAxiosError: true,
+    response: {
+      status,
+      data: message ? { message } : undefined,
+    },
+  };
+}
+
+describe('authentication saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('initSaga', () => {
+    it('loads the access token from localStorage when creating the store', () => {
+      seedAccessToken('some-token');
+
+      const store = createTestStore();
+
+      expect(store.getState().authentication.accessToken).toBe('some-token');
+    });
+
+    it('leaves the access token null when nothing was seeded', () => {
+      const store = createTestStore();
+
+      expect(store.getState().authentication.accessToken).toBeNull();
+    });
+  });
+
+  describe('loginRequestedSaga', () => {
+    it('logs in and stores the access token on success', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthLogin.mockResolvedValue({
+        data: { token: 'token-123' },
+      } as any);
+
+      store.dispatch(
+        actions.loginRequested({ email: 'User@Example.com', password: 'pw' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.accessToken).toBe('token-123');
+      expect(store.getState().authentication.login.status).toBe('SUCCEEDED');
+      expect(store.getState().authentication.loginError).toBeNull();
+      expect(mockedApi.postAuthLogin).toHaveBeenCalledWith({
+        email: 'user@example.com',
+        password: 'pw',
+      });
+    });
+
+    it('dispatches loginFailed with UNVERIFIED_EMAIL for a 401 unverified-email error', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthLogin.mockRejectedValue(
+        buildAxiosError(401, 'UNVERIFIED_EMAIL')
+      );
+
+      store.dispatch(
+        actions.loginRequested({ email: 'user@example.com', password: 'pw' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.login.status).toBe('FAILED');
+      expect(store.getState().authentication.loginError).toBe(
+        'UNVERIFIED_EMAIL'
+      );
+    });
+
+    it('dispatches loginFailed with INVALID_CREDENTIALS for a generic error', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthLogin.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.loginRequested({ email: 'user@example.com', password: 'pw' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.login.status).toBe('FAILED');
+      expect(store.getState().authentication.loginError).toBe(
+        'INVALID_CREDENTIALS'
+      );
+    });
+
+    // The saga's catch block has no `return`/`else` after its first `if
+    // (isTooManyRequests(error))`, so a 429 error falls through to the
+    // `isEmailUnverifiedError` check (false) and its `else` branch, which
+    // dispatches a second `loginFailed` that overwrites the first. The final
+    // state ends up INVALID_CREDENTIALS, not RATE_LIMIT, for a rate-limited
+    // login. This test documents that actual (likely unintended) behavior
+    // rather than the probably-intended one; see report for details.
+    it('ends up with INVALID_CREDENTIALS (not RATE_LIMIT) for a 429 error, due to a fall-through in the saga', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthLogin.mockRejectedValue(buildAxiosError(429));
+
+      store.dispatch(
+        actions.loginRequested({ email: 'user@example.com', password: 'pw' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.login.status).toBe('FAILED');
+      expect(store.getState().authentication.loginError).toBe(
+        'INVALID_CREDENTIALS'
+      );
+    });
+  });
+
+  describe('loginSucceededSaga', () => {
+    it('writes the access token to localStorage', async () => {
+      const store = createTestStore();
+
+      store.dispatch(actions.loginSucceeded({ accessToken: 'direct-token' }));
+      await flushPromises();
+
+      expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBe(
+        'direct-token'
+      );
+      expect(store.getState().authentication.accessToken).toBe('direct-token');
+    });
+  });
+
+  describe('logoutRequestedSaga', () => {
+    it('logs out successfully', async () => {
+      seedAccessToken('token-123');
+      const store = createTestStore();
+
+      store.dispatch(actions.logoutRequested());
+      await flushPromises();
+
+      expect(store.getState().authentication.logout.status).toBe('SUCCEEDED');
+      expect(store.getState().authentication.accessToken).toBeNull();
+    });
+  });
+
+  describe('logoutSucceededSaga', () => {
+    it('removes the access token from localStorage', async () => {
+      seedAccessToken('token-123');
+      const store = createTestStore();
+      expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBe('token-123');
+
+      store.dispatch(actions.logoutSucceeded());
+      await flushPromises();
+
+      expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBeNull();
+    });
+  });
+
+  describe('verifyEmailTokenSaga', () => {
+    it('succeeds when the API call resolves', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyEmailToken.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.verifyEmailTokenRequested({ token: 'email-token' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.verifyEmailToken.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('sets ALREADY_VERIFIED when the email was already verified', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyEmailToken.mockRejectedValue(
+        buildAxiosError(400, 'EMAIL_ALREADY_VERIFIED')
+      );
+
+      store.dispatch(
+        actions.verifyEmailTokenRequested({ token: 'email-token' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.verifyEmailToken.status).toBe(
+        'FAILED'
+      );
+      expect(store.getState().authentication.verifyEmailTokenError).toBe(2); // ALREADY_VERIFIED
+    });
+
+    it('sets TOKEN_EXPIRED when the token has expired', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyEmailToken.mockRejectedValue(
+        buildAxiosError(400, 'TOKEN_EXPIRED')
+      );
+
+      store.dispatch(
+        actions.verifyEmailTokenRequested({ token: 'email-token' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.verifyEmailTokenError).toBe(0); // TOKEN_EXPIRED
+    });
+
+    it('sets TOKEN_INVALID for any other error', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyEmailToken.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.verifyEmailTokenRequested({ token: 'email-token' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.verifyEmailTokenError).toBe(1); // TOKEN_INVALID
+    });
+  });
+
+  describe('sendVerifyEmailSaga', () => {
+    it('succeeds when the API call resolves', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthSendVerifyEmail.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.sendVerifyEmailRequested({ email: 'user@example.com' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.sendVerifyEmail.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('fails when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthSendVerifyEmail.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.sendVerifyEmailRequested({ email: 'user@example.com' })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.sendVerifyEmail.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('verifyOtpSaga', () => {
+    it('logs in, succeeds, and triggers a cross-domain current-user profile fetch', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyOtp.mockResolvedValue({
+        data: { token: 'otp-token' },
+      } as any);
+      const profile = { id: 'profile-1' } as any;
+      mockedApi.getCurrentProfile.mockResolvedValue({ data: profile } as any);
+
+      store.dispatch(
+        actions.verifyOtpRequested({
+          email: 'user@example.com',
+          code: '123456',
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.accessToken).toBe('otp-token');
+      expect(store.getState().authentication.login.status).toBe('SUCCEEDED');
+      expect(store.getState().authentication.verifyOtp.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(store.getState().authentication.verifyOtpError).toBeNull();
+      // The cross-domain fetchCurrentProfileRequested dispatched by
+      // verifyOtpSaga is guarded on selectAccessToken, which is already set
+      // by the time it fires (loginSucceeded is put earlier in the same
+      // saga), so the guarded fetch actually runs and succeeds.
+      expect(store.getState().currentUser.profile).toEqual(profile);
+      expect(store.getState().currentUser.fetchCurrentProfile.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('sets EXPIRED when the OTP has expired', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyOtp.mockRejectedValue(
+        buildAxiosError(400, 'OTP_EXPIRED')
+      );
+
+      store.dispatch(
+        actions.verifyOtpRequested({
+          email: 'user@example.com',
+          code: '123456',
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.verifyOtp.status).toBe('FAILED');
+      expect(store.getState().authentication.verifyOtpError).toBe('EXPIRED');
+      expect(store.getState().authentication.accessToken).toBeNull();
+    });
+
+    it('sets INVALID for any other error', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthVerifyOtp.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.verifyOtpRequested({
+          email: 'user@example.com',
+          code: '123456',
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.verifyOtp.status).toBe('FAILED');
+      expect(store.getState().authentication.verifyOtpError).toBe('INVALID');
+    });
+  });
+});

--- a/src/use-cases/authentication/authentication.selectors.spec.ts
+++ b/src/use-cases/authentication/authentication.selectors.spec.ts
@@ -1,0 +1,109 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import {
+  logoutSelectors,
+  selectAccessToken,
+  selectLoginError,
+  selectVerifyEmailTokenError,
+  selectVerifyOtpError,
+  sendVerifyEmailSelectors,
+  verifyEmailTokenSelectors,
+  verifyOtpSelectors,
+} from './authentication.selectors';
+import { RootState, slice } from './authentication.slice';
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    authentication: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('authentication.selectors', () => {
+  describe('selectAccessToken', () => {
+    it('returns the access token', () => {
+      expect(selectAccessToken(buildState({ accessToken: 'token-123' }))).toBe(
+        'token-123'
+      );
+    });
+
+    it('returns null when there is no access token', () => {
+      expect(selectAccessToken(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectLoginError', () => {
+    it('returns the login error', () => {
+      expect(selectLoginError(buildState({ loginError: 'RATE_LIMIT' }))).toBe(
+        'RATE_LIMIT'
+      );
+    });
+
+    it('returns null when there is no login error', () => {
+      expect(selectLoginError(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectVerifyEmailTokenError', () => {
+    it('returns the verifyEmailToken error', () => {
+      expect(
+        selectVerifyEmailTokenError(buildState({ verifyEmailTokenError: 1 }))
+      ).toBe(1);
+    });
+
+    it('returns null when there is no verifyEmailToken error', () => {
+      expect(selectVerifyEmailTokenError(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectVerifyOtpError', () => {
+    it('returns the verifyOtp error', () => {
+      expect(
+        selectVerifyOtpError(buildState({ verifyOtpError: 'INVALID' as any }))
+      ).toBe('INVALID');
+    });
+
+    it('returns null when there is no verifyOtp error', () => {
+      expect(selectVerifyOtpError(buildState())).toBeNull();
+    });
+  });
+
+  const adapterStatusSelectors: [
+    string,
+    (state: RootState) => string,
+    'logout' | 'verifyEmailToken' | 'sendVerifyEmail' | 'verifyOtp',
+  ][] = [
+    [
+      'selectLogoutStatus',
+      (logoutSelectors as any).selectLogoutStatus,
+      'logout',
+    ],
+    [
+      'selectVerifyEmailTokenStatus',
+      (verifyEmailTokenSelectors as any).selectVerifyEmailTokenStatus,
+      'verifyEmailToken',
+    ],
+    [
+      'selectSendVerifyEmailStatus',
+      (sendVerifyEmailSelectors as any).selectSendVerifyEmailStatus,
+      'sendVerifyEmail',
+    ],
+    [
+      'selectVerifyOtpStatus',
+      (verifyOtpSelectors as any).selectVerifyOtpStatus,
+      'verifyOtp',
+    ],
+  ];
+
+  adapterStatusSelectors.forEach(([name, selector, stateKey]) => {
+    describe(name, () => {
+      it(`reads the status from authentication.${stateKey}`, () => {
+        const state = buildState({
+          [stateKey]: { status: 'SUCCEEDED' },
+        } as any);
+
+        expect(selector(state)).toBe('SUCCEEDED');
+      });
+    });
+  });
+});

--- a/src/use-cases/authentication/authentication.slice.spec.ts
+++ b/src/use-cases/authentication/authentication.slice.spec.ts
@@ -1,0 +1,130 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { slice } from './authentication.slice';
+
+const { actions, reducer } = slice;
+
+describe('authentication slice', () => {
+  describe('loginSucceeded', () => {
+    it('sets the access token and clears the login error', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        loginError: 'INVALID_CREDENTIALS' as const,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.loginSucceeded({ accessToken: 'token-123' })
+      );
+
+      expect(state.accessToken).toBe('token-123');
+      expect(state.loginError).toBeNull();
+      expect(state.login.status).toBe('SUCCEEDED');
+    });
+  });
+
+  describe('loginFailed', () => {
+    it('sets the login error', () => {
+      const state = reducer(
+        undefined,
+        actions.loginFailed({ error: 'RATE_LIMIT' })
+      );
+
+      expect(state.loginError).toBe('RATE_LIMIT');
+      expect(state.login.status).toBe('FAILED');
+    });
+  });
+
+  describe('logoutSucceeded', () => {
+    it('clears the access token', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        accessToken: 'token-123',
+      };
+
+      const state = reducer(initialState, actions.logoutSucceeded());
+
+      expect(state.accessToken).toBeNull();
+      expect(state.logout.status).toBe('SUCCEEDED');
+    });
+  });
+
+  describe('verifyEmailTokenFailed', () => {
+    it('sets the verifyEmailToken error', () => {
+      const state = reducer(
+        undefined,
+        actions.verifyEmailTokenFailed({ error: 1 })
+      );
+
+      expect(state.verifyEmailTokenError).toBe(1);
+      expect(state.verifyEmailToken.status).toBe('FAILED');
+    });
+  });
+
+  describe('verifyOtpFailed', () => {
+    it('sets the verifyOtp error', () => {
+      const state = reducer(
+        undefined,
+        actions.verifyOtpFailed({ error: 'INVALID' as any })
+      );
+
+      expect(state.verifyOtpError).toBe('INVALID');
+      expect(state.verifyOtp.status).toBe('FAILED');
+    });
+  });
+
+  describe('verifyOtpSucceeded', () => {
+    it('clears the verifyOtp error', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        verifyOtpError: 'INVALID' as any,
+      };
+
+      const state = reducer(initialState, actions.verifyOtpSucceeded());
+
+      expect(state.verifyOtpError).toBeNull();
+      expect(state.verifyOtp.status).toBe('SUCCEEDED');
+    });
+  });
+
+  describe('setAccessToken', () => {
+    it('sets the access token', () => {
+      const state = reducer(undefined, actions.setAccessToken('token-abc'));
+
+      expect(state.accessToken).toBe('token-abc');
+    });
+
+    it('resets the access token to null', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        accessToken: 'token-abc',
+      };
+
+      const state = reducer(initialState, actions.setAccessToken(null));
+
+      expect(state.accessToken).toBeNull();
+    });
+  });
+
+  describe('setVerifyEmailTokenError', () => {
+    it('sets the verifyEmailToken error', () => {
+      const state = reducer(undefined, actions.setVerifyEmailTokenError(2));
+
+      expect(state.verifyEmailTokenError).toBe(2);
+    });
+
+    it('resets the verifyEmailToken error to null', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        verifyEmailTokenError: 2,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setVerifyEmailTokenError(null)
+      );
+
+      expect(state.verifyEmailTokenError).toBeNull();
+    });
+  });
+});

--- a/src/use-cases/company/company.saga.spec.ts
+++ b/src/use-cases/company/company.saga.spec.ts
@@ -1,0 +1,318 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { CompaniesFilters } from '@/src/api/types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
+import { slice } from './company.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildFilters = (overrides: Partial<CompaniesFilters> = {}) =>
+  ({
+    departments: [],
+    businessSectorIds: [],
+    onlyWithReferent: false,
+    ...overrides,
+  }) as CompaniesFilters;
+
+describe('company saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchCompaniesRequested', () => {
+    it('stores the returned companies on success', async () => {
+      const store = createTestStore();
+      const companies = [{ id: 'company-1' }] as any;
+      mockedApi.getAllCompanies.mockResolvedValue({ data: companies } as any);
+
+      store.dispatch(actions.fetchCompaniesRequested(buildFilters()));
+      await flushPromises();
+
+      expect(store.getState().company.companies).toEqual(companies);
+      expect(store.getState().company.fetchCompanies.status).toBe('SUCCEEDED');
+    });
+
+    it('dispatches fetchCompaniesFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getAllCompanies.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchCompaniesRequested(buildFilters()));
+      await flushPromises();
+
+      expect(store.getState().company.fetchCompanies.status).toBe('FAILED');
+    });
+  });
+
+  describe('fetchCompaniesWithFilters', () => {
+    it('resets pagination and fetches companies with the given filters', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          companiesOffset: 50,
+          companiesHasFetchedAll: true,
+        },
+      });
+      const companies = [{ id: 'company-1' }] as any;
+      mockedApi.getAllCompanies.mockResolvedValue({ data: companies } as any);
+
+      store.dispatch(
+        actions.fetchCompaniesWithFilters(buildFilters({ search: 'acme' }))
+      );
+      await flushPromises();
+
+      expect(store.getState().company.companiesOffset).toBe(0);
+      expect(store.getState().company.companies).toEqual(companies);
+      expect(mockedApi.getAllCompanies).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'acme', offset: 0 })
+      );
+    });
+  });
+
+  describe('fetchCompaniesNextPage', () => {
+    it('fetches the next page when not all companies were fetched and no fetch is in flight', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          companiesHasFetchedAll: false,
+        },
+      });
+      mockedApi.getAllCompanies.mockResolvedValue({ data: [] } as any);
+
+      store.dispatch(actions.fetchCompaniesNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllCompanies).toHaveBeenCalled();
+    });
+
+    it('does nothing when all companies have already been fetched', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          companiesHasFetchedAll: true,
+        },
+      });
+
+      store.dispatch(actions.fetchCompaniesNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllCompanies).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when a fetch is already in flight', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          companiesHasFetchedAll: false,
+          fetchCompanies: { status: 'REQUESTED' as any },
+        },
+      });
+
+      store.dispatch(actions.fetchCompaniesNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllCompanies).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchSelectedCompanyRequested', () => {
+    it('stores the selected company on success', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          selectedCompanyId: 'company-1',
+        },
+      });
+      const company = { id: 'company-1' } as any;
+      mockedApi.getCompanyById.mockResolvedValue({ data: company } as any);
+
+      store.dispatch(actions.fetchSelectedCompanyRequested());
+      await flushPromises();
+
+      expect(store.getState().company.selectedCompany).toEqual(company);
+    });
+
+    it('dispatches fetchSelectedCompanyFailed when there is no selected company id', async () => {
+      const store = createTestStore();
+
+      store.dispatch(actions.fetchSelectedCompanyRequested());
+      await flushPromises();
+
+      expect(mockedApi.getCompanyById).not.toHaveBeenCalled();
+      expect(store.getState().company.fetchSelectedCompany.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('fetchSelectedCompanyWithCollaboratorsRequested', () => {
+    it('stores the result on success', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          selectedCompanyId: 'company-1',
+        },
+      });
+      const company = { id: 'company-1', users: [] } as any;
+      mockedApi.getCompanyByIdWithUsersAndPendingInvitations.mockResolvedValue({
+        data: company,
+      } as any);
+
+      store.dispatch(actions.fetchSelectedCompanyWithCollaboratorsRequested());
+      await flushPromises();
+
+      expect(store.getState().company.selectedCompanyWithCollaborators).toEqual(
+        company
+      );
+    });
+
+    it('notifies on failure', async () => {
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          selectedCompanyId: 'company-1',
+        },
+      });
+      mockedApi.getCompanyByIdWithUsersAndPendingInvitations.mockRejectedValue(
+        new Error('boom')
+      );
+
+      store.dispatch(actions.fetchSelectedCompanyWithCollaboratorsRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().company.fetchSelectedCompanyWithCollaborators.status
+      ).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+  });
+
+  describe('inviteCollaboratorsRequested', () => {
+    it('notifies, re-fetches the selected company and the current user on success', async () => {
+      seedAccessToken('token-123');
+      const store = createTestStore({
+        company: {
+          ...slice.getInitialState(),
+          selectedCompanyId: 'company-1',
+        },
+      });
+      mockedApi.inviteCollaboratorsFromCompany.mockResolvedValue({} as any);
+      mockedApi.getCompanyByIdWithUsersAndPendingInvitations.mockResolvedValue({
+        data: { id: 'company-1' },
+      } as any);
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+
+      store.dispatch(
+        actions.inviteCollaboratorsRequested({
+          companyId: 'company-1',
+          emails: ['a@example.com'],
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().company.inviteCollaborators.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().company.selectedCompanyWithCollaborators).toEqual(
+        { id: 'company-1' }
+      );
+      expect(store.getState().currentUser.user).toEqual({ id: 'user-1' });
+    });
+
+    it('notifies of the failure and does not re-fetch on rejection', async () => {
+      const store = createTestStore();
+      mockedApi.inviteCollaboratorsFromCompany.mockRejectedValue(
+        new Error('boom')
+      );
+
+      store.dispatch(
+        actions.inviteCollaboratorsRequested({
+          companyId: 'company-1',
+          emails: ['a@example.com'],
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().company.inviteCollaborators.status).toBe(
+        'FAILED'
+      );
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+  });
+
+  describe('updateCompanyLogoRequested', () => {
+    it('succeeds when the upload resolves', async () => {
+      const store = createTestStore();
+      mockedApi.updateCompanyLogo.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.updateCompanyLogoRequested({
+          companyId: 'company-1',
+          logoFile: new File([], 'logo.png'),
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().company.updateCompanyLogo.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('fails when the upload rejects', async () => {
+      const store = createTestStore();
+      mockedApi.updateCompanyLogo.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateCompanyLogoRequested({
+          companyId: 'company-1',
+          logoFile: new File([], 'logo.png'),
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().company.updateCompanyLogo.status).toBe('FAILED');
+    });
+  });
+
+  describe('updateCompanyRequested', () => {
+    it('notifies and re-fetches the current user on success', async () => {
+      seedAccessToken('token-123');
+      const store = createTestStore();
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+
+      store.dispatch(
+        actions.updateCompanyRequested({ companyData: { name: 'Acme' } })
+      );
+      await flushPromises();
+
+      expect(store.getState().company.updateCompany.status).toBe('SUCCEEDED');
+      expect(store.getState().currentUser.user).toEqual({ id: 'user-1' });
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+
+    it('notifies of the failure when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.updateCompany.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateCompanyRequested({ companyData: { name: 'Acme' } })
+      );
+      await flushPromises();
+
+      expect(store.getState().company.updateCompany.status).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+  });
+});

--- a/src/use-cases/company/company.selectors.spec.ts
+++ b/src/use-cases/company/company.selectors.spec.ts
@@ -1,0 +1,70 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { CompanyWithUsers } from '@/src/api/types';
+import {
+  selectCompanies,
+  selectCompaniesHasFetchedAll,
+  selectCompaniesOffset,
+  selectSelectedCompany,
+  selectSelectedCompanyId,
+  selectSelectedCompanyWithCollaborators,
+} from './company.selectors';
+import { RootState, slice } from './company.slice';
+
+const buildCompany = (overrides: Partial<CompanyWithUsers> = {}) =>
+  ({
+    id: 'company-1',
+    name: 'Acme',
+    ...overrides,
+  }) as CompanyWithUsers;
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    company: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('company.selectors', () => {
+  it('selectSelectedCompanyId returns the selected company id', () => {
+    expect(
+      selectSelectedCompanyId(buildState({ selectedCompanyId: 'company-1' }))
+    ).toBe('company-1');
+  });
+
+  it('selectSelectedCompany returns the selected company', () => {
+    const company = buildCompany();
+    expect(
+      selectSelectedCompany(buildState({ selectedCompany: company }))
+    ).toEqual(company);
+  });
+
+  it('selectSelectedCompanyWithCollaborators returns the selected company with collaborators', () => {
+    const company = buildCompany();
+    expect(
+      selectSelectedCompanyWithCollaborators(
+        buildState({ selectedCompanyWithCollaborators: company })
+      )
+    ).toEqual(company);
+  });
+
+  it('selectCompanies returns the companies list', () => {
+    const companies = [buildCompany()];
+    expect(selectCompanies(buildState({ companies }))).toEqual(companies);
+  });
+
+  it('selectCompaniesHasFetchedAll returns the pagination flag', () => {
+    expect(
+      selectCompaniesHasFetchedAll(buildState({ companiesHasFetchedAll: true }))
+    ).toBe(true);
+    expect(
+      selectCompaniesHasFetchedAll(
+        buildState({ companiesHasFetchedAll: false })
+      )
+    ).toBe(false);
+  });
+
+  it('selectCompaniesOffset returns the current pagination offset', () => {
+    expect(selectCompaniesOffset(buildState({ companiesOffset: 25 }))).toBe(25);
+  });
+});

--- a/src/use-cases/company/company.slice.spec.ts
+++ b/src/use-cases/company/company.slice.spec.ts
@@ -1,0 +1,196 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { CompaniesFilters, CompanyWithUsers } from '@/src/api/types';
+import { COMPANIES_LIMIT } from '@/src/constants';
+import { slice } from './company.slice';
+
+const { actions, reducer } = slice;
+
+const buildCompany = (overrides: Partial<CompanyWithUsers> = {}) =>
+  ({
+    id: 'company-1',
+    name: 'Acme',
+    ...overrides,
+  }) as CompanyWithUsers;
+
+const buildFilters = (overrides: Partial<CompaniesFilters> = {}) =>
+  ({
+    departments: [],
+    businessSectorIds: [],
+    onlyWithReferent: false,
+    ...overrides,
+  }) as CompaniesFilters;
+
+describe('company slice', () => {
+  describe('fetchCompaniesSucceeded', () => {
+    it('replaces the companies list when offset is 0', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        companiesOffset: 0,
+        companies: [buildCompany({ id: 'stale' })],
+      };
+      const companies = [buildCompany({ id: 'company-1' })];
+
+      const state = reducer(
+        initialState,
+        actions.fetchCompaniesSucceeded(companies)
+      );
+
+      expect(state.companies).toEqual(companies);
+    });
+
+    it('appends to the companies list when offset is greater than 0', () => {
+      const existing = [buildCompany({ id: 'company-1' })];
+      const initialState = {
+        ...slice.getInitialState(),
+        companiesOffset: COMPANIES_LIMIT,
+        companies: existing,
+      };
+      const nextPage = [buildCompany({ id: 'company-2' })];
+
+      const state = reducer(
+        initialState,
+        actions.fetchCompaniesSucceeded(nextPage)
+      );
+
+      expect(state.companies).toEqual([...existing, ...nextPage]);
+    });
+
+    it('marks companiesHasFetchedAll true when the page is smaller than the limit', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchCompaniesSucceeded([buildCompany()])
+      );
+
+      expect(state.companiesHasFetchedAll).toBe(true);
+    });
+
+    it('marks companiesHasFetchedAll false when the page is full', () => {
+      const fullPage = Array.from({ length: COMPANIES_LIMIT }, (_, i) =>
+        buildCompany({ id: `company-${i}` })
+      );
+
+      const state = reducer(
+        undefined,
+        actions.fetchCompaniesSucceeded(fullPage)
+      );
+
+      expect(state.companiesHasFetchedAll).toBe(false);
+    });
+  });
+
+  it('fetchSelectedCompanySucceeded sets selectedCompany', () => {
+    const company = buildCompany();
+
+    const state = reducer(
+      undefined,
+      actions.fetchSelectedCompanySucceeded(company)
+    );
+
+    expect(state.selectedCompany).toEqual(company);
+  });
+
+  it('fetchSelectedCompanyWithCollaboratorsSucceeded sets selectedCompanyWithCollaborators', () => {
+    const company = buildCompany();
+
+    const state = reducer(
+      undefined,
+      actions.fetchSelectedCompanyWithCollaboratorsSucceeded(company)
+    );
+
+    expect(state.selectedCompanyWithCollaborators).toEqual(company);
+  });
+
+  it('setSelectedCompanyId sets the selected company id', () => {
+    const state = reducer(undefined, actions.setSelectedCompanyId('company-1'));
+
+    expect(state.selectedCompanyId).toBe('company-1');
+  });
+
+  it('setSelectedCompanyId can clear the selected company id', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      selectedCompanyId: 'company-1',
+    };
+
+    const state = reducer(initialState, actions.setSelectedCompanyId(null));
+
+    expect(state.selectedCompanyId).toBeNull();
+  });
+
+  it('resetCompaniesOffset resets pagination state', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      companiesOffset: COMPANIES_LIMIT * 2,
+      companiesHasFetchedAll: true,
+      companies: [buildCompany()],
+    };
+
+    const state = reducer(initialState, actions.resetCompaniesOffset());
+
+    expect(state.companiesOffset).toBe(0);
+    expect(state.companiesHasFetchedAll).toBe(false);
+    expect(state.companies).toEqual([]);
+  });
+
+  it('fetchCompaniesWithFilters does not mutate state', () => {
+    const initialState = slice.getInitialState();
+
+    const state = reducer(
+      initialState,
+      actions.fetchCompaniesWithFilters(buildFilters())
+    );
+
+    expect(state).toEqual(initialState);
+  });
+
+  describe('fetchCompaniesNextPage', () => {
+    it('increments the offset when not all companies are fetched and the previous fetch succeeded', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        companiesOffset: 0,
+        companiesHasFetchedAll: false,
+        fetchCompanies: { status: 'SUCCEEDED' as const },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchCompaniesNextPage(buildFilters())
+      );
+
+      expect(state.companiesOffset).toBe(COMPANIES_LIMIT);
+    });
+
+    it('does not increment the offset when all companies are already fetched', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        companiesOffset: 0,
+        companiesHasFetchedAll: true,
+        fetchCompanies: { status: 'SUCCEEDED' as const },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchCompaniesNextPage(buildFilters())
+      );
+
+      expect(state.companiesOffset).toBe(0);
+    });
+
+    it('does not increment the offset when a fetch is still in progress', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        companiesOffset: 0,
+        companiesHasFetchedAll: false,
+        fetchCompanies: { status: 'REQUESTED' as const },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchCompaniesNextPage(buildFilters())
+      );
+
+      expect(state.companiesOffset).toBe(0);
+    });
+  });
+});

--- a/src/use-cases/current-user/current-user.saga.spec.ts
+++ b/src/use-cases/current-user/current-user.saga.spec.ts
@@ -1,0 +1,768 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
+import { authenticationActions } from '@/src/use-cases/authentication';
+import { slice } from './current-user.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+function buildAuthenticatedStore() {
+  seedAccessToken('token-123');
+  return createTestStore();
+}
+
+describe('current-user saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchUserRequested', () => {
+    it('fetches the current user and dispatches fetchUserSucceeded when authenticated', async () => {
+      const store = buildAuthenticatedStore();
+      const user = { id: 'user-1', onboardingStatus: 'IN_PROGRESS' } as any;
+      mockedApi.getCurrentIdentity.mockResolvedValue({ data: user } as any);
+
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.user).toEqual(user);
+      expect(store.getState().currentUser.fetchUser.status).toBe('SUCCEEDED');
+    });
+
+    it('dispatches fetchUserFailed without calling the API when there is no access token', async () => {
+      const store = createTestStore();
+
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+
+      expect(mockedApi.getCurrentIdentity).not.toHaveBeenCalled();
+      expect(store.getState().currentUser.fetchUser.status).toBe('FAILED');
+    });
+
+    it('dispatches fetchUserFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockRejectedValue(
+        new Error('network error')
+      );
+
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.fetchUser.status).toBe('FAILED');
+    });
+
+    it('stores the onboarding status in localStorage once fetched', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1', onboardingStatus: 'COMPLETED' },
+      } as any);
+
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+
+      expect(localStorage.getItem('onboarding-completion-status')).toBe(
+        'COMPLETED'
+      );
+    });
+  });
+
+  describe('fetchCompleteUserRequested', () => {
+    it('triggers fetchCurrentProfileComplete and lands its result', async () => {
+      const store = buildAuthenticatedStore();
+      const profileComplete = { id: 'profile-1' } as any;
+      mockedApi.getCurrentProfileComplete.mockResolvedValue({
+        data: profileComplete,
+      } as any);
+
+      store.dispatch(actions.fetchCompleteUserRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.profileComplete).toEqual(
+        profileComplete
+      );
+      expect(store.getState().currentUser.complete).toBe(true);
+    });
+  });
+
+  describe('updateUserRequested', () => {
+    it('updates the user and does not log out when the email is unchanged', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1', email: 'same@example.com' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.putUser.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.updateUserRequested({
+          userId: 'user-1',
+          user: { email: 'same@example.com' },
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateUser.status).toBe('SUCCEEDED');
+      expect(store.getState().authentication.logout.status).toBe('IDLE');
+    });
+
+    it('logs the user out when the email changes', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1', email: 'old@example.com' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.putUser.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.updateUserRequested({
+          userId: 'user-1',
+          user: { email: 'new@example.com' },
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().authentication.logout.status).toBe('SUCCEEDED');
+    });
+
+    it('dispatches updateUserFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.putUser.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateUserRequested({
+          userId: 'user-1',
+          user: { email: 'new@example.com' },
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateUser.status).toBe('FAILED');
+      expect(store.getState().currentUser.userUpdateError).toBe(
+        'UPDATE_FAILED'
+      );
+    });
+  });
+
+  describe('updateOnboardingStatusRequested', () => {
+    it('updates the onboarding status on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.putUser.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.updateOnboardingStatusRequested({
+          onboardingStatus: 'COMPLETED' as any,
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.user?.onboardingStatus).toBe(
+        'COMPLETED'
+      );
+      expect(store.getState().currentUser.updateOnboardingStatus.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('dispatches updateOnboardingStatusFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.putUser.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateOnboardingStatusRequested({
+          onboardingStatus: 'COMPLETED' as any,
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateOnboardingStatus.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('forceOnboardingAsCompletedRequested', () => {
+    it('forces the onboarding status to the API response value', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.putUser.mockResolvedValue({
+        data: { onboardingStatus: 'COMPLETED' },
+      } as any);
+
+      store.dispatch(actions.forceOnboardingAsCompletedRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.user?.onboardingStatus).toBe(
+        'COMPLETED'
+      );
+    });
+
+    it('dispatches forceOnboardingAsCompletedFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.putUser.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.forceOnboardingAsCompletedRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().currentUser.forceOnboardingAsCompleted.status
+      ).toBe('FAILED');
+    });
+  });
+
+  describe('updateUserCompanyRequested', () => {
+    it('re-fetches the current user on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.putUserCompany.mockResolvedValue({} as any);
+      const refreshedUser = { id: 'user-1', company: 'Acme' } as any;
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: refreshedUser,
+      } as any);
+
+      store.dispatch(
+        actions.updateUserCompanyRequested({ companyName: 'Acme' })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateUserCompany.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(store.getState().currentUser.user).toEqual(refreshedUser);
+    });
+
+    it('notifies and sets the error on failure', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.putUserCompany.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateUserCompanyRequested({ companyName: 'Acme' })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateUserCompany.status).toBe(
+        'FAILED'
+      );
+      expect(store.getState().currentUser.userCompanyUpdateError).toBe(
+        'UPDATE_FAILED'
+      );
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+  });
+
+  describe('updateProfileRequested', () => {
+    it('re-fetches the complete profile when one was already loaded', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentProfileComplete.mockResolvedValue({
+        data: { id: 'profile-1' },
+      } as any);
+      store.dispatch(actions.fetchCurrentProfileCompleteRequested());
+      await flushPromises();
+
+      mockedApi.putUserProfile.mockResolvedValue({
+        data: { description: 'Updated bio' },
+      } as any);
+      mockedApi.getCurrentProfileComplete.mockResolvedValue({
+        data: { id: 'profile-1', description: 'Updated bio' },
+      } as any);
+
+      store.dispatch(
+        actions.updateProfileRequested({
+          userId: 'user-1',
+          userProfile: { description: 'Updated bio' } as any,
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.profileComplete?.description).toBe(
+        'Updated bio'
+      );
+    });
+
+    it('dispatches updateProfileFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.putUserProfile.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateProfileRequested({
+          userId: 'user-1',
+          userProfile: {} as any,
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateProfile.status).toBe('FAILED');
+      expect(store.getState().currentUser.userUpdateError).toBe(
+        'UPDATE_FAILED'
+      );
+    });
+  });
+
+  describe('updateSocialSituationRequested', () => {
+    it('re-fetches the current user on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+
+      mockedApi.updateUserSocialSituation.mockResolvedValue({} as any);
+      const refreshedUser = { id: 'user-1', updated: true } as any;
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: refreshedUser,
+      } as any);
+
+      store.dispatch(actions.updateSocialSituationRequested({}));
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateSocialSituation.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(store.getState().currentUser.user).toEqual(refreshedUser);
+    });
+
+    it('dispatches updateSocialSituationFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.updateUserSocialSituation.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.updateSocialSituationRequested({}));
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateSocialSituation.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('readDocumentRequested', () => {
+    it('marks the document as read and re-fetches the current user', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+
+      mockedApi.postReadDocument.mockReturnValue(undefined as any);
+      const refreshedUser = { id: 'user-1', updated: true } as any;
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: refreshedUser,
+      } as any);
+
+      store.dispatch(
+        actions.readDocumentRequested({ documentName: 'cgu' as any })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.readDocument.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(store.getState().currentUser.user).toEqual(refreshedUser);
+    });
+  });
+
+  describe('updateUserProfilePictureRequested', () => {
+    it('succeeds when the upload resolves', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.postProfileImage.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.updateUserProfilePictureRequested({
+          profileImage: new Blob(),
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateUserProfilePicture.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('fails when the upload rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.postProfileImage.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateUserProfilePictureRequested({
+          profileImage: new Blob(),
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.updateUserProfilePicture.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('deleteExternalCvRequested', () => {
+    it('resets hasExternalCv and notifies on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentProfile.mockResolvedValue({
+        data: { hasExternalCv: true },
+      } as any);
+      store.dispatch(actions.fetchCurrentProfileRequested());
+      await flushPromises();
+      mockedApi.deleteExternalCv.mockResolvedValue({} as any);
+
+      store.dispatch(actions.deleteExternalCvRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.profile?.hasExternalCv).toBe(false);
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+
+    it('leaves the profile unchanged and does not notify when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentProfile.mockResolvedValue({
+        data: { hasExternalCv: true },
+      } as any);
+      store.dispatch(actions.fetchCurrentProfileRequested());
+      await flushPromises();
+      mockedApi.deleteExternalCv.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.deleteExternalCvRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.profile?.hasExternalCv).toBe(true);
+      expect(store.getState().notifications.notifications).toHaveLength(0);
+    });
+  });
+
+  describe('uploadExternalCvRequested', () => {
+    it('succeeds when the upload resolves', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.postExternalCv.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.uploadExternalCvRequested({ formData: new FormData() })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.uploadExternalCv.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('notifies and fails when the upload rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.postExternalCv.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.uploadExternalCvRequested({ formData: new FormData() })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.uploadExternalCv.status).toBe(
+        'FAILED'
+      );
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+  });
+
+  describe('getExternalCvRequested', () => {
+    it('sets the external CV url on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.getExternalCvByUser.mockResolvedValue({
+        data: { url: 'https://cv.pdf' },
+      } as any);
+
+      store.dispatch(actions.getExternalCvRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.externalCv).toBe('https://cv.pdf');
+    });
+
+    it('dispatches getExternalCvFailed when the API call rejects', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      mockedApi.getExternalCvByUser.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.getExternalCvRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.externalCv).toBeNull();
+    });
+  });
+
+  describe('loginSucceeded / logoutSucceeded (cross-domain)', () => {
+    it('fetches the current user when authentication succeeds', async () => {
+      const store = createTestStore();
+      const user = { id: 'user-1' } as any;
+      mockedApi.getCurrentIdentity.mockResolvedValue({ data: user } as any);
+
+      store.dispatch(
+        authenticationActions.loginSucceeded({ accessToken: 'token-123' })
+      );
+      await flushPromises();
+
+      expect(store.getState().currentUser.user).toEqual(user);
+    });
+
+    it('resets the current-user slice when authentication logs out', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      store.dispatch(actions.fetchUserRequested());
+      await flushPromises();
+      expect(store.getState().currentUser.user).not.toBeNull();
+
+      store.dispatch(authenticationActions.logoutSucceeded());
+      await flushPromises();
+
+      expect(store.getState().currentUser.user).toBeNull();
+    });
+  });
+
+  const guardedFetchers: {
+    name: string;
+    requested: () => { type: string; payload: unknown };
+    apiMethod: keyof ReturnType<typeof getMockedApi>;
+    mockData: unknown;
+    statusField:
+      | 'fetchStaffContact'
+      | 'fetchCurrentProfile'
+      | 'fetchCurrentCompany'
+      | 'fetchCurrentOrganization'
+      | 'fetchCurrentAchievements'
+      | 'fetchCurrentReadDocuments'
+      | 'fetchCurrentReferredUsers'
+      | 'fetchCurrentReferrer'
+      | 'fetchUserStats';
+    resultField:
+      | 'staffContact'
+      | 'profile'
+      | 'company'
+      | 'organization'
+      | 'achievements'
+      | 'readDocuments'
+      | 'stats'
+      | null;
+  }[] = [
+    {
+      name: 'fetchStaffContactRequested',
+      requested: () => actions.fetchStaffContactRequested(),
+      apiMethod: 'getCurrentStaffContact',
+      mockData: { name: 'Coach' },
+      statusField: 'fetchStaffContact',
+      resultField: 'staffContact',
+    },
+    {
+      name: 'fetchCurrentProfileRequested',
+      requested: () => actions.fetchCurrentProfileRequested(),
+      apiMethod: 'getCurrentProfile',
+      mockData: { id: 'profile-1' },
+      statusField: 'fetchCurrentProfile',
+      resultField: 'profile',
+    },
+    {
+      name: 'fetchCurrentCompanyRequested',
+      requested: () => actions.fetchCurrentCompanyRequested(),
+      apiMethod: 'getCurrentCompany',
+      mockData: { id: 'company-1' },
+      statusField: 'fetchCurrentCompany',
+      resultField: 'company',
+    },
+    {
+      name: 'fetchCurrentOrganizationRequested',
+      requested: () => actions.fetchCurrentOrganizationRequested(),
+      apiMethod: 'getCurrentOrganization',
+      mockData: { id: 'org-1' },
+      statusField: 'fetchCurrentOrganization',
+      resultField: 'organization',
+    },
+    {
+      name: 'fetchUserStatsRequested',
+      requested: () => actions.fetchUserStatsRequested(),
+      apiMethod: 'getCurrentStats',
+      mockData: { profileViews: 3 },
+      statusField: 'fetchUserStats',
+      resultField: 'stats',
+    },
+  ];
+
+  guardedFetchers.forEach(
+    ({ name, requested, apiMethod, mockData, statusField, resultField }) => {
+      describe(name, () => {
+        it('succeeds and stores the API payload when authenticated', async () => {
+          const store = buildAuthenticatedStore();
+          (mockedApi[apiMethod] as jest.Mock).mockResolvedValue({
+            data: mockData,
+          });
+
+          store.dispatch(requested());
+          await flushPromises();
+
+          expect(
+            (store.getState().currentUser as any)[statusField].status
+          ).toBe('SUCCEEDED');
+          if (resultField) {
+            expect((store.getState().currentUser as any)[resultField]).toEqual(
+              mockData
+            );
+          }
+        });
+
+        it('fails without calling the API when there is no access token', async () => {
+          const store = createTestStore();
+
+          store.dispatch(requested());
+          await flushPromises();
+
+          expect(mockedApi[apiMethod]).not.toHaveBeenCalled();
+          expect(
+            (store.getState().currentUser as any)[statusField].status
+          ).toBe('FAILED');
+        });
+
+        it('fails when the API call rejects', async () => {
+          const store = buildAuthenticatedStore();
+          (mockedApi[apiMethod] as jest.Mock).mockRejectedValue(
+            new Error('boom')
+          );
+
+          store.dispatch(requested());
+          await flushPromises();
+
+          expect(
+            (store.getState().currentUser as any)[statusField].status
+          ).toBe('FAILED');
+        });
+      });
+    }
+  );
+
+  describe('fetchCurrentAchievementsRequested', () => {
+    it('stores the achievements list on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentAchievements.mockResolvedValue({
+        data: { achievements: [{ id: 'ach-1' }] },
+      } as any);
+
+      store.dispatch(actions.fetchCurrentAchievementsRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.achievements).toEqual([
+        { id: 'ach-1' },
+      ]);
+    });
+  });
+
+  describe('fetchCurrentReadDocumentsRequested', () => {
+    it('stores the read documents list on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentReadDocuments.mockResolvedValue({
+        data: { readDocuments: [{ documentName: 'cgu', createdAt: 'now' }] },
+      } as any);
+
+      store.dispatch(actions.fetchCurrentReadDocumentsRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.readDocuments).toEqual([
+        { documentName: 'cgu', createdAt: 'now' },
+      ]);
+    });
+  });
+
+  describe('fetchCurrentReferredUsersRequested', () => {
+    it('stores the referred candidates as referredUsers on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentReferredUsers.mockResolvedValue({
+        data: { referredCandidates: [{ id: 'candidate-1' }] },
+      } as any);
+
+      store.dispatch(actions.fetchCurrentReferredUsersRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.referredUsers).toEqual([
+        { id: 'candidate-1' },
+      ]);
+    });
+  });
+
+  describe('fetchCurrentReferrerRequested', () => {
+    it('stores the referrer on success', async () => {
+      const store = buildAuthenticatedStore();
+      mockedApi.getCurrentReferrer.mockResolvedValue({
+        data: { id: 'referrer-1' },
+      } as any);
+
+      store.dispatch(actions.fetchCurrentReferrerRequested());
+      await flushPromises();
+
+      expect(store.getState().currentUser.referrer).toEqual({
+        id: 'referrer-1',
+      });
+    });
+  });
+
+  describe('fetchCurrentUserSocialSituationRequested (unguarded)', () => {
+    it('succeeds without needing an access token', async () => {
+      const store = createTestStore();
+      mockedApi.getUserSocialSituation.mockResolvedValue({
+        data: { hasCompletedSurvey: true },
+      } as any);
+
+      store.dispatch(actions.fetchCurrentUserSocialSituationRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().currentUser.fetchCurrentUserSocialSituation.status
+      ).toBe('SUCCEEDED');
+    });
+
+    it('fails when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getUserSocialSituation.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchCurrentUserSocialSituationRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().currentUser.fetchCurrentUserSocialSituation.status
+      ).toBe('FAILED');
+    });
+  });
+});

--- a/src/use-cases/current-user/current-user.selectors.spec.ts
+++ b/src/use-cases/current-user/current-user.selectors.spec.ts
@@ -1,0 +1,285 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { FeatureKey, User } from '@/src/api/types';
+import {
+  selectAuthenticatedUser,
+  selectBetaFeatures,
+  selectCurrentUser,
+  selectCurrentUserAchievements,
+  selectCurrentUserCompany,
+  selectCurrentUserId,
+  selectCurrentUserOrganization,
+  selectCurrentUserProfile,
+  selectCurrentUserProfileComplete,
+  selectCurrentUserReadDocuments,
+  selectCurrentUserReferredUsers,
+  selectCurrentUserReferrer,
+  selectCurrentUserStats,
+  selectExternalCv,
+  selectFetchCurrentAchievementsStatus,
+  selectFetchCurrentCompanyStatus,
+  selectFetchCurrentOrganizationStatus,
+  selectFetchCurrentProfileCompleteStatus,
+  selectFetchCurrentProfileStatus,
+  selectFetchCurrentReadDocumentsStatus,
+  selectFetchCurrentReferredUsersStatus,
+  selectFetchCurrentReferrerStatus,
+  selectFetchUserStatsStatus,
+  selectHasBetaFeature,
+  selectIsComplete,
+  selectStaffContact,
+} from './current-user.selectors';
+import { RootState } from './current-user.slice';
+import { slice } from './current-user.slice';
+
+const buildUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: 'user-1',
+    email: 'user@example.com',
+    betaFeatures: {},
+    ...overrides,
+  }) as User;
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    currentUser: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('current-user.selectors', () => {
+  describe('selectCurrentUser', () => {
+    it('returns the current user', () => {
+      const user = buildUser();
+      expect(selectCurrentUser(buildState({ user }))).toBe(user);
+    });
+
+    it('returns null when there is no user', () => {
+      expect(selectCurrentUser(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectAuthenticatedUser', () => {
+    it('returns the current user when defined', () => {
+      const user = buildUser();
+      expect(selectAuthenticatedUser(buildState({ user }))).toBe(user);
+    });
+
+    it('throws when there is no authenticated user', () => {
+      expect(() => selectAuthenticatedUser(buildState())).toThrow();
+    });
+  });
+
+  describe('selectCurrentUserId', () => {
+    it("returns the authenticated user's id", () => {
+      const user = buildUser({ id: 'user-42' });
+      expect(selectCurrentUserId(buildState({ user }))).toBe('user-42');
+    });
+
+    it('throws when there is no authenticated user', () => {
+      expect(() => selectCurrentUserId(buildState())).toThrow();
+    });
+  });
+
+  describe('selectStaffContact', () => {
+    it('returns the staff contact', () => {
+      const staffContact = { name: 'Coach' } as any;
+      expect(selectStaffContact(buildState({ staffContact }))).toEqual(
+        staffContact
+      );
+    });
+  });
+
+  describe('selectExternalCv', () => {
+    it('returns the external CV url', () => {
+      expect(
+        selectExternalCv(buildState({ externalCv: 'https://cv.pdf' }))
+      ).toBe('https://cv.pdf');
+    });
+  });
+
+  describe('selectCurrentUserStats', () => {
+    it('returns the user stats', () => {
+      const stats = { profileViews: 1 } as any;
+      expect(selectCurrentUserStats(buildState({ stats }))).toEqual(stats);
+    });
+  });
+
+  describe('selectIsComplete', () => {
+    it('returns the complete flag', () => {
+      expect(selectIsComplete(buildState({ complete: true }))).toBe(true);
+      expect(selectIsComplete(buildState({ complete: false }))).toBe(false);
+    });
+  });
+
+  describe('selectCurrentUserProfile', () => {
+    it('returns the profile', () => {
+      const profile = { firstName: 'A' } as any;
+      expect(selectCurrentUserProfile(buildState({ profile }))).toEqual(
+        profile
+      );
+    });
+  });
+
+  describe('selectCurrentUserProfileComplete', () => {
+    it('returns the complete profile', () => {
+      const profileComplete = { firstName: 'A' } as any;
+      expect(
+        selectCurrentUserProfileComplete(buildState({ profileComplete }))
+      ).toEqual(profileComplete);
+    });
+  });
+
+  describe('selectCurrentUserCompany', () => {
+    it('returns the company', () => {
+      const company = { id: 'company-1' } as any;
+      expect(selectCurrentUserCompany(buildState({ company }))).toEqual(
+        company
+      );
+    });
+  });
+
+  describe('selectCurrentUserOrganization', () => {
+    it('returns the organization', () => {
+      const organization = { id: 'org-1' } as any;
+      expect(
+        selectCurrentUserOrganization(buildState({ organization }))
+      ).toEqual(organization);
+    });
+  });
+
+  describe('selectCurrentUserAchievements', () => {
+    it('returns the achievements list', () => {
+      const achievements = [{ id: 'ach-1' }] as any;
+      expect(
+        selectCurrentUserAchievements(buildState({ achievements }))
+      ).toEqual(achievements);
+    });
+  });
+
+  describe('selectCurrentUserReadDocuments', () => {
+    it('returns the read documents list', () => {
+      const readDocuments = [{ documentName: 'cgu', createdAt: 'now' }];
+      expect(
+        selectCurrentUserReadDocuments(buildState({ readDocuments }))
+      ).toEqual(readDocuments);
+    });
+  });
+
+  describe('selectCurrentUserReferredUsers', () => {
+    it('returns the referred users list', () => {
+      const referredUsers = [{ id: 'candidate-1' }] as any;
+      expect(
+        selectCurrentUserReferredUsers(buildState({ referredUsers }))
+      ).toEqual(referredUsers);
+    });
+  });
+
+  describe('selectCurrentUserReferrer', () => {
+    it('returns the referrer', () => {
+      const referrer = { id: 'referrer-1' } as any;
+      expect(selectCurrentUserReferrer(buildState({ referrer }))).toEqual(
+        referrer
+      );
+    });
+  });
+
+  describe('selectBetaFeatures', () => {
+    it("returns the user's beta features", () => {
+      const user = buildUser({
+        betaFeatures: { [FeatureKey.MESSAGING_AI_ASSISTANT]: true },
+      });
+      expect(selectBetaFeatures(buildState({ user }))).toEqual({
+        [FeatureKey.MESSAGING_AI_ASSISTANT]: true,
+      });
+    });
+
+    it('returns an empty object when there is no user', () => {
+      expect(selectBetaFeatures(buildState())).toEqual({});
+    });
+  });
+
+  describe('selectHasBetaFeature', () => {
+    it('returns true when the feature flag is enabled for the user', () => {
+      const user = buildUser({
+        betaFeatures: { [FeatureKey.MESSAGING_AI_ASSISTANT]: true },
+      });
+      expect(
+        selectHasBetaFeature(FeatureKey.MESSAGING_AI_ASSISTANT)(
+          buildState({ user })
+        )
+      ).toBe(true);
+    });
+
+    it('returns false when the feature flag is absent', () => {
+      const user = buildUser({
+        betaFeatures: { [FeatureKey.MESSAGING_AI_ASSISTANT]: false },
+      });
+      expect(
+        selectHasBetaFeature(FeatureKey.MESSAGING_AI_ASSISTANT)(
+          buildState({ user })
+        )
+      ).toBe(false);
+    });
+  });
+
+  const statusSelectors: [string, (state: RootState) => string, string][] = [
+    [
+      'selectFetchCurrentCompanyStatus',
+      selectFetchCurrentCompanyStatus,
+      'fetchCurrentCompany',
+    ],
+    [
+      'selectFetchCurrentProfileStatus',
+      selectFetchCurrentProfileStatus,
+      'fetchCurrentProfile',
+    ],
+    [
+      'selectFetchCurrentProfileCompleteStatus',
+      selectFetchCurrentProfileCompleteStatus,
+      'fetchCurrentProfileComplete',
+    ],
+    [
+      'selectFetchCurrentOrganizationStatus',
+      selectFetchCurrentOrganizationStatus,
+      'fetchCurrentOrganization',
+    ],
+    [
+      'selectFetchCurrentAchievementsStatus',
+      selectFetchCurrentAchievementsStatus,
+      'fetchCurrentAchievements',
+    ],
+    [
+      'selectFetchCurrentReadDocumentsStatus',
+      selectFetchCurrentReadDocumentsStatus,
+      'fetchCurrentReadDocuments',
+    ],
+    [
+      'selectFetchCurrentReferredUsersStatus',
+      selectFetchCurrentReferredUsersStatus,
+      'fetchCurrentReferredUsers',
+    ],
+    [
+      'selectFetchCurrentReferrerStatus',
+      selectFetchCurrentReferrerStatus,
+      'fetchCurrentReferrer',
+    ],
+    [
+      'selectFetchUserStatsStatus',
+      selectFetchUserStatsStatus,
+      'fetchUserStats',
+    ],
+  ];
+
+  statusSelectors.forEach(([name, selector, stateKey]) => {
+    describe(name, () => {
+      it(`reads the status from currentUser.${stateKey}`, () => {
+        const state = buildState({
+          [stateKey]: { status: 'SUCCEEDED' },
+        } as any);
+
+        expect(selector(state)).toBe('SUCCEEDED');
+      });
+    });
+  });
+});

--- a/src/use-cases/current-user/current-user.slice.spec.ts
+++ b/src/use-cases/current-user/current-user.slice.spec.ts
@@ -1,0 +1,419 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { User } from '@/src/api/types';
+import { slice } from './current-user.slice';
+
+const { actions, reducer } = slice;
+
+const buildUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: 'user-1',
+    email: 'user@example.com',
+    onboardingStatus: 'IN_PROGRESS',
+    betaFeatures: {},
+    ...overrides,
+  }) as User;
+
+describe('current-user slice', () => {
+  it('resetCurrentUser returns the initial state', () => {
+    const mutated = reducer(undefined, actions.setUser(buildUser()));
+
+    expect(reducer(mutated, actions.resetCurrentUser())).toEqual(
+      slice.getInitialState()
+    );
+  });
+
+  it('setUser sets the user', () => {
+    const user = buildUser();
+
+    const state = reducer(undefined, actions.setUser(user));
+
+    expect(state.user).toEqual(user);
+  });
+
+  it('fetchUserSucceeded sets the user and resets complete to false', () => {
+    const initialState = { ...slice.getInitialState(), complete: true };
+    const user = buildUser();
+
+    const state = reducer(initialState, actions.fetchUserSucceeded(user));
+
+    expect(state.user).toEqual(user);
+    expect(state.complete).toBe(false);
+  });
+
+  it('fetchUserStatsSucceeded sets stats', () => {
+    const stats = { profileViews: 3 } as any;
+
+    const state = reducer(undefined, actions.fetchUserStatsSucceeded(stats));
+
+    expect(state.stats).toEqual(stats);
+  });
+
+  it('fetchCurrentUserSocialSituationSucceeded merges into user.userSocialSituation', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      user: buildUser({
+        userSocialSituation: { nationality: 'FR' } as any,
+      }),
+    };
+
+    const state = reducer(
+      initialState,
+      actions.fetchCurrentUserSocialSituationSucceeded({
+        hasCompletedSurvey: true,
+      })
+    );
+
+    expect(state.user?.userSocialSituation).toEqual({
+      nationality: 'FR',
+      hasCompletedSurvey: true,
+    });
+  });
+
+  it('fetchCurrentUserSocialSituationSucceeded is a no-op when there is no user yet', () => {
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentUserSocialSituationSucceeded({
+        hasCompletedSurvey: true,
+      })
+    );
+
+    expect(state.user).toBeNull();
+  });
+
+  it('fetchStaffContactSucceeded sets staffContact', () => {
+    const staffContact = { name: 'Coach' } as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchStaffContactSucceeded(staffContact)
+    );
+
+    expect(state.staffContact).toEqual(staffContact);
+  });
+
+  it('fetchCompleteUserSucceeded sets the user and complete to true', () => {
+    const user = buildUser();
+
+    const state = reducer(undefined, actions.fetchCompleteUserSucceeded(user));
+
+    expect(state.user).toEqual(user);
+    expect(state.complete).toBe(true);
+  });
+
+  it('updateUserSucceeded merges the payload into the existing user', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      user: buildUser({ email: 'old@example.com' }),
+    };
+
+    const state = reducer(
+      initialState,
+      actions.updateUserSucceeded({ user: { email: 'new@example.com' } })
+    );
+
+    expect(state.user?.email).toBe('new@example.com');
+  });
+
+  it('updateUserSucceeded throws when there is no authenticated user', () => {
+    expect(() =>
+      reducer(
+        undefined,
+        actions.updateUserSucceeded({ user: { email: 'new@example.com' } })
+      )
+    ).toThrow();
+  });
+
+  it('updateUserFailed sets userUpdateError', () => {
+    const state = reducer(
+      undefined,
+      actions.updateUserFailed({ error: 'UPDATE_FAILED' })
+    );
+
+    expect(state.userUpdateError).toBe('UPDATE_FAILED');
+  });
+
+  it('updateUserCompanyFailed sets userCompanyUpdateError', () => {
+    const state = reducer(
+      undefined,
+      actions.updateUserCompanyFailed({ error: 'UPDATE_FAILED' })
+    );
+
+    expect(state.userCompanyUpdateError).toBe('UPDATE_FAILED');
+  });
+
+  it('updateUserCompanySucceeded only transitions the request status', () => {
+    const state = reducer(undefined, actions.updateUserCompanySucceeded());
+
+    expect(state.updateUserCompany.status).toBe('SUCCEEDED');
+  });
+
+  it('updateProfileSucceeded merges userProfile into profile and profileComplete', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profile: { firstName: 'Old' } as any,
+      profileComplete: { firstName: 'Old', hasPicture: false } as any,
+    };
+
+    const state = reducer(
+      initialState,
+      actions.updateProfileSucceeded({
+        userProfile: { firstName: 'New' } as any,
+      })
+    );
+
+    expect(state.profile).toEqual({ firstName: 'New' });
+    expect(state.profileComplete).toEqual({
+      firstName: 'New',
+      hasPicture: false,
+    });
+  });
+
+  it('updateProfileSucceeded is a no-op on profile/profileComplete when both are null', () => {
+    const state = reducer(
+      undefined,
+      actions.updateProfileSucceeded({
+        userProfile: { firstName: 'New' } as any,
+      })
+    );
+
+    expect(state.profile).toBeNull();
+    expect(state.profileComplete).toBeNull();
+  });
+
+  it('updateProfileFailed sets userUpdateError', () => {
+    const state = reducer(
+      undefined,
+      actions.updateProfileFailed({ error: 'UPDATE_FAILED' })
+    );
+
+    expect(state.userUpdateError).toBe('UPDATE_FAILED');
+  });
+
+  it('updateOnboardingStatusSucceeded sets user.onboardingStatus', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      user: buildUser({ onboardingStatus: 'NOT_STARTED' as any }),
+    };
+
+    const state = reducer(
+      initialState,
+      actions.updateOnboardingStatusSucceeded({
+        onboardingStatus: 'COMPLETED' as any,
+      })
+    );
+
+    expect(state.user?.onboardingStatus).toBe('COMPLETED');
+  });
+
+  it('updateOnboardingStatusSucceeded throws when there is no authenticated user', () => {
+    expect(() =>
+      reducer(
+        undefined,
+        actions.updateOnboardingStatusSucceeded({
+          onboardingStatus: 'COMPLETED' as any,
+        })
+      )
+    ).toThrow();
+  });
+
+  it('forceOnboardingAsCompletedSucceeded sets user.onboardingStatus', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      user: buildUser({ onboardingStatus: 'NOT_STARTED' as any }),
+    };
+
+    const state = reducer(
+      initialState,
+      actions.forceOnboardingAsCompletedSucceeded({
+        onboardingStatus: 'COMPLETED' as any,
+      })
+    );
+
+    expect(state.user?.onboardingStatus).toBe('COMPLETED');
+  });
+
+  it('updateUserProfilePictureSucceeded sets hasPicture on profile and profileComplete', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profile: { hasPicture: false } as any,
+      profileComplete: { hasPicture: false } as any,
+    };
+
+    const state = reducer(
+      initialState,
+      actions.updateUserProfilePictureSucceeded()
+    );
+
+    expect(state.profile?.hasPicture).toBe(true);
+    expect(state.profileComplete?.hasPicture).toBe(true);
+  });
+
+  it('uploadExternalCvSucceeded sets hasExternalCv and resets hasExtractedCvData', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profile: { hasExternalCv: false } as any,
+      profileComplete: {
+        hasExternalCv: false,
+        hasExtractedCvData: true,
+      } as any,
+    };
+
+    const state = reducer(initialState, actions.uploadExternalCvSucceeded());
+
+    expect(state.profile?.hasExternalCv).toBe(true);
+    expect(state.profileComplete?.hasExternalCv).toBe(true);
+    expect(state.profileComplete?.hasExtractedCvData).toBe(false);
+  });
+
+  it('fetchCurrentProfileSucceeded sets profile', () => {
+    const profile = { firstName: 'A' } as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentProfileSucceeded(profile)
+    );
+
+    expect(state.profile).toEqual(profile);
+  });
+
+  it('fetchCurrentProfileCompleteSucceeded sets profileComplete and complete to true', () => {
+    const profileComplete = { firstName: 'A' } as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentProfileCompleteSucceeded(profileComplete)
+    );
+
+    expect(state.profileComplete).toEqual(profileComplete);
+    expect(state.complete).toBe(true);
+  });
+
+  it('fetchCurrentCompanySucceeded sets company', () => {
+    const company = { id: 'company-1' } as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentCompanySucceeded(company)
+    );
+
+    expect(state.company).toEqual(company);
+  });
+
+  it('fetchCurrentOrganizationSucceeded sets organization', () => {
+    const organization = { id: 'org-1' } as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentOrganizationSucceeded(organization)
+    );
+
+    expect(state.organization).toEqual(organization);
+  });
+
+  it('fetchCurrentAchievementsSucceeded sets achievements', () => {
+    const achievements = [{ id: 'ach-1' }] as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentAchievementsSucceeded(achievements)
+    );
+
+    expect(state.achievements).toEqual(achievements);
+  });
+
+  it('fetchCurrentReadDocumentsSucceeded sets readDocuments', () => {
+    const readDocuments = [{ documentName: 'cgu', createdAt: '2026-01-01' }];
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentReadDocumentsSucceeded(readDocuments)
+    );
+
+    expect(state.readDocuments).toEqual(readDocuments);
+  });
+
+  it('fetchCurrentReferredUsersSucceeded sets referredUsers from referredCandidates', () => {
+    const referredCandidates = [{ id: 'candidate-1' }] as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentReferredUsersSucceeded({ referredCandidates })
+    );
+
+    expect(state.referredUsers).toEqual(referredCandidates);
+  });
+
+  it('fetchCurrentReferrerSucceeded sets referrer', () => {
+    const referrer = { id: 'referrer-1' } as any;
+
+    const state = reducer(
+      undefined,
+      actions.fetchCurrentReferrerSucceeded(referrer)
+    );
+
+    expect(state.referrer).toEqual(referrer);
+  });
+
+  it('deleteExternalCvSucceeded resets hasExternalCv on profile and profileComplete', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profile: { hasExternalCv: true } as any,
+      profileComplete: { hasExternalCv: true } as any,
+    };
+
+    const state = reducer(initialState, actions.deleteExternalCvSucceeded());
+
+    expect(state.profile?.hasExternalCv).toBe(false);
+    expect(state.profileComplete?.hasExternalCv).toBe(false);
+  });
+
+  it('getExternalCvSucceeded sets externalCv', () => {
+    const state = reducer(
+      undefined,
+      actions.getExternalCvSucceeded('https://example.com/cv.pdf')
+    );
+
+    expect(state.externalCv).toBe('https://example.com/cv.pdf');
+  });
+
+  it('generateProfileFromCVSucceeded sets hasExtractedCvData on profileComplete', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profileComplete: { hasExtractedCvData: false } as any,
+    };
+
+    const state = reducer(
+      initialState,
+      actions.generateProfileFromCVSucceeded()
+    );
+
+    expect(state.profileComplete?.hasExtractedCvData).toBe(true);
+  });
+
+  it('profileCompleteDraftUpdated merges the partial payload into profileComplete', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profileComplete: { description: 'Old', isAvailable: true } as any,
+    };
+
+    const state = reducer(
+      initialState,
+      actions.profileCompleteDraftUpdated({ description: 'New' })
+    );
+
+    expect(state.profileComplete).toEqual({
+      description: 'New',
+      isAvailable: true,
+    });
+  });
+
+  it('profileCompleteDraftUpdated is a no-op when profileComplete is null', () => {
+    const state = reducer(
+      undefined,
+      actions.profileCompleteDraftUpdated({ description: 'New' })
+    );
+
+    expect(state.profileComplete).toBeNull();
+  });
+});

--- a/src/use-cases/elearning/elearning.saga.spec.ts
+++ b/src/use-cases/elearning/elearning.saga.spec.ts
@@ -1,0 +1,144 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { UserRoles } from '@/src/constants/users';
+import {
+  ElearningCompletion,
+  ElearningUnit,
+} from '@/src/features/backoffice/elearning/elearning.types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
+import { authenticationActions } from '@/src/use-cases/authentication';
+import { slice } from './elearning.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildUnit = (overrides: Partial<ElearningUnit> = {}): ElearningUnit => ({
+  id: 'unit-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  title: 'Unit 1',
+  description: 'Description',
+  durationMinutes: 10,
+  videoUrl: 'https://example.com/video.mp4',
+  questions: [],
+  roles: [],
+  userCompletions: [],
+  ...overrides,
+});
+
+const buildCompletion = (
+  overrides: Partial<ElearningCompletion> = {}
+): ElearningCompletion => ({
+  id: 'completion-1',
+  userId: 'user-1',
+  unitId: 'unit-1',
+  validatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('elearning saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchElearningUnitsRequested', () => {
+    it('stores the returned units on success', async () => {
+      const store = createTestStore();
+      const units = [buildUnit()];
+      mockedApi.getAllElearningUnits.mockResolvedValue({ data: units } as any);
+
+      store.dispatch(actions.fetchElearningUnitsRequested(UserRoles.CANDIDATE));
+      await flushPromises();
+
+      expect(store.getState().elearning.elearningUnits).toEqual(units);
+      expect(store.getState().elearning.fetchElearningUnits.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('dispatches fetchElearningUnitsFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getAllElearningUnits.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchElearningUnitsRequested(UserRoles.CANDIDATE));
+      await flushPromises();
+
+      expect(store.getState().elearning.fetchElearningUnits.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('postElearningCompletionRequested', () => {
+    it('stores the completion, marks the request as succeeded and re-fetches the current user', async () => {
+      seedAccessToken('token-123');
+      const store = createTestStore({
+        elearning: {
+          ...slice.getInitialState(),
+          elearningUnits: [buildUnit({ id: 'unit-1', userCompletions: [] })],
+        },
+      });
+      const completion = buildCompletion({ unitId: 'unit-1' });
+      mockedApi.postElearningCompletion.mockResolvedValue({
+        data: completion,
+      } as any);
+      const refreshedUser = { id: 'user-1' } as any;
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: refreshedUser,
+      } as any);
+
+      store.dispatch(
+        actions.postElearningCompletionRequested({ unitId: 'unit-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().elearning.postElearningCompletion.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(
+        store.getState().elearning.elearningUnits[0].userCompletions
+      ).toEqual([completion]);
+      expect(store.getState().currentUser.user).toEqual(refreshedUser);
+    });
+
+    it('dispatches postElearningCompletionFailed and does not re-fetch the current user when the API call rejects', async () => {
+      seedAccessToken('token-123');
+      const store = createTestStore();
+      mockedApi.postElearningCompletion.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.postElearningCompletionRequested({ unitId: 'unit-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().elearning.postElearningCompletion.status).toBe(
+        'FAILED'
+      );
+      expect(mockedApi.getCurrentIdentity).not.toHaveBeenCalled();
+      expect(store.getState().currentUser.fetchUser.status).toBe('IDLE');
+    });
+  });
+
+  describe('logoutSucceeded (cross-domain)', () => {
+    it('resets the elearning slice when authentication logs out', async () => {
+      const store = createTestStore({
+        elearning: {
+          ...slice.getInitialState(),
+          elearningUnits: [buildUnit()],
+          isLoading: true,
+        },
+      });
+
+      store.dispatch(authenticationActions.logoutSucceeded());
+      await flushPromises();
+
+      expect(store.getState().elearning).toEqual(slice.getInitialState());
+    });
+  });
+});

--- a/src/use-cases/elearning/elearning.selectors.spec.ts
+++ b/src/use-cases/elearning/elearning.selectors.spec.ts
@@ -1,0 +1,68 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { ElearningUnit } from '@/src/features/backoffice/elearning/elearning.types';
+import {
+  selectElearningUnits,
+  selectFetchElearningUnitsState,
+  selectIsLoading,
+} from './elearning.selectors';
+import { RootState, slice } from './elearning.slice';
+
+const buildUnit = (overrides: Partial<ElearningUnit> = {}): ElearningUnit => ({
+  id: 'unit-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  title: 'Unit 1',
+  description: 'Description',
+  durationMinutes: 10,
+  videoUrl: 'https://example.com/video.mp4',
+  questions: [],
+  roles: [],
+  userCompletions: [],
+  ...overrides,
+});
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    elearning: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('elearning.selectors', () => {
+  describe('selectIsLoading', () => {
+    it('returns true when isLoading is true', () => {
+      expect(selectIsLoading(buildState({ isLoading: true }))).toBe(true);
+    });
+
+    it('returns false when isLoading is false', () => {
+      expect(selectIsLoading(buildState({ isLoading: false }))).toBe(false);
+    });
+  });
+
+  describe('selectElearningUnits', () => {
+    it('returns the elearning units list', () => {
+      const units = [buildUnit()];
+
+      expect(
+        selectElearningUnits(buildState({ elearningUnits: units }))
+      ).toEqual(units);
+    });
+
+    it('returns an empty array when there are no units', () => {
+      expect(selectElearningUnits(buildState())).toEqual([]);
+    });
+  });
+
+  describe('selectFetchElearningUnitsState', () => {
+    it('returns the fetchElearningUnits request state', () => {
+      const state = buildState({
+        fetchElearningUnits: { status: 'SUCCEEDED' } as any,
+      });
+
+      expect(selectFetchElearningUnitsState(state)).toEqual({
+        status: 'SUCCEEDED',
+      });
+    });
+  });
+});

--- a/src/use-cases/elearning/elearning.slice.spec.ts
+++ b/src/use-cases/elearning/elearning.slice.spec.ts
@@ -1,0 +1,216 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { UserRoles } from '@/src/constants/users';
+import {
+  ElearningCompletion,
+  ElearningUnit,
+} from '@/src/features/backoffice/elearning/elearning.types';
+import { slice } from './elearning.slice';
+
+const { actions, reducer } = slice;
+
+const buildCompletion = (
+  overrides: Partial<ElearningCompletion> = {}
+): ElearningCompletion => ({
+  id: 'completion-1',
+  userId: 'user-1',
+  unitId: 'unit-1',
+  validatedAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const buildUnit = (overrides: Partial<ElearningUnit> = {}): ElearningUnit => ({
+  id: 'unit-1',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  title: 'Unit 1',
+  description: 'Description',
+  durationMinutes: 10,
+  videoUrl: 'https://example.com/video.mp4',
+  questions: [],
+  roles: [],
+  userCompletions: [],
+  ...overrides,
+});
+
+describe('elearning slice', () => {
+  describe('fetchElearningUnitsRequested', () => {
+    it('sets the fetchElearningUnits status to REQUESTED', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchElearningUnitsRequested(UserRoles.CANDIDATE)
+      );
+
+      expect(state.fetchElearningUnits.status).toBe('REQUESTED');
+    });
+  });
+
+  describe('fetchElearningUnitsSucceeded', () => {
+    it('sets elearningUnits and the status to SUCCEEDED', () => {
+      const units = [buildUnit()];
+
+      const state = reducer(
+        undefined,
+        actions.fetchElearningUnitsSucceeded(units)
+      );
+
+      expect(state.elearningUnits).toEqual(units);
+      expect(state.fetchElearningUnits.status).toBe('SUCCEEDED');
+    });
+  });
+
+  describe('fetchElearningUnitsFailed', () => {
+    it('sets the fetchElearningUnits status to FAILED', () => {
+      const state = reducer(undefined, actions.fetchElearningUnitsFailed());
+
+      expect(state.fetchElearningUnits.status).toBe('FAILED');
+    });
+  });
+
+  describe('postElearningCompletionRequested', () => {
+    it('sets the postElearningCompletion status to REQUESTED', () => {
+      const state = reducer(
+        undefined,
+        actions.postElearningCompletionRequested({ unitId: 'unit-1' })
+      );
+
+      expect(state.postElearningCompletion.status).toBe('REQUESTED');
+    });
+  });
+
+  describe('postElearningCompletionSucceeded', () => {
+    it('sets the postElearningCompletion status to SUCCEEDED', () => {
+      const state = reducer(
+        undefined,
+        actions.postElearningCompletionSucceeded(buildCompletion())
+      );
+
+      expect(state.postElearningCompletion.status).toBe('SUCCEEDED');
+    });
+
+    it('adds the completion to the matching unit when it has none yet', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        elearningUnits: [buildUnit({ id: 'unit-1', userCompletions: [] })],
+      };
+      const completion = buildCompletion({
+        id: 'completion-1',
+        unitId: 'unit-1',
+      });
+
+      const state = reducer(
+        initialState,
+        actions.postElearningCompletionSucceeded(completion)
+      );
+
+      expect(state.elearningUnits[0].userCompletions).toEqual([completion]);
+    });
+
+    it('replaces (rather than appends) the existing completion for the same unit', () => {
+      const staleCompletion = buildCompletion({
+        id: 'completion-stale',
+        unitId: 'unit-1',
+        validatedAt: '2026-01-01T00:00:00.000Z',
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        elearningUnits: [
+          buildUnit({ id: 'unit-1', userCompletions: [staleCompletion] }),
+        ],
+      };
+      const updatedCompletion = buildCompletion({
+        id: 'completion-fresh',
+        unitId: 'unit-1',
+        validatedAt: '2026-02-01T00:00:00.000Z',
+      });
+
+      const state = reducer(
+        initialState,
+        actions.postElearningCompletionSucceeded(updatedCompletion)
+      );
+
+      expect(state.elearningUnits[0].userCompletions).toEqual([
+        updatedCompletion,
+      ]);
+    });
+
+    it('leaves completions for other units untouched', () => {
+      const otherUnitCompletion = buildCompletion({
+        id: 'completion-other',
+        unitId: 'unit-2',
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        elearningUnits: [
+          buildUnit({ id: 'unit-1', userCompletions: [] }),
+          buildUnit({ id: 'unit-2', userCompletions: [otherUnitCompletion] }),
+        ],
+      };
+      const completion = buildCompletion({
+        id: 'completion-1',
+        unitId: 'unit-1',
+      });
+
+      const state = reducer(
+        initialState,
+        actions.postElearningCompletionSucceeded(completion)
+      );
+
+      expect(state.elearningUnits[1].userCompletions).toEqual([
+        otherUnitCompletion,
+      ]);
+    });
+
+    it('is a no-op on elearningUnits when the completion targets an unknown unit', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        elearningUnits: [buildUnit({ id: 'unit-1', userCompletions: [] })],
+      };
+      const completion = buildCompletion({ unitId: 'unknown-unit' });
+
+      const state = reducer(
+        initialState,
+        actions.postElearningCompletionSucceeded(completion)
+      );
+
+      expect(state.elearningUnits).toEqual(initialState.elearningUnits);
+    });
+  });
+
+  describe('postElearningCompletionFailed', () => {
+    it('sets the postElearningCompletion status to FAILED', () => {
+      const state = reducer(undefined, actions.postElearningCompletionFailed());
+
+      expect(state.postElearningCompletion.status).toBe('FAILED');
+    });
+  });
+
+  describe('setIsLoading', () => {
+    it('sets isLoading to true', () => {
+      const state = reducer(undefined, actions.setIsLoading(true));
+
+      expect(state.isLoading).toBe(true);
+    });
+
+    it('sets isLoading to false', () => {
+      const initialState = { ...slice.getInitialState(), isLoading: true };
+
+      const state = reducer(initialState, actions.setIsLoading(false));
+
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('resetElearning', () => {
+    it('returns the initial state', () => {
+      const mutated = reducer(
+        undefined,
+        actions.fetchElearningUnitsSucceeded([buildUnit()])
+      );
+
+      expect(reducer(mutated, actions.resetElearning())).toEqual(
+        slice.getInitialState()
+      );
+    });
+  });
+});

--- a/src/use-cases/events/events.saga.spec.ts
+++ b/src/use-cases/events/events.saga.spec.ts
@@ -1,0 +1,245 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { EventDirectoryFilters } from '@/src/features/backoffice/events/EventDirectory/useEventDirectoryQueryParams';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice } from './events.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildFilters = (
+  overrides: Partial<EventDirectoryFilters> = {}
+): EventDirectoryFilters => ({
+  ...overrides,
+});
+
+describe('events saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchEventsRequested', () => {
+    it('stores the returned events on success', async () => {
+      const store = createTestStore();
+      const events = [{ salesForceId: 'event-1' }] as any;
+      mockedApi.getAllEvents.mockResolvedValue({ data: events } as any);
+
+      store.dispatch(actions.fetchEventsRequested(buildFilters()));
+      await flushPromises();
+
+      expect(store.getState().events.events).toEqual(events);
+      expect(store.getState().events.fetchEvents.status).toBe('SUCCEEDED');
+    });
+
+    it('dispatches fetchEventsFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getAllEvents.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchEventsRequested(buildFilters()));
+      await flushPromises();
+
+      expect(store.getState().events.fetchEvents.status).toBe('FAILED');
+    });
+  });
+
+  describe('fetchEventsWithFilters', () => {
+    it('resets pagination and fetches events with the given filters', async () => {
+      const store = createTestStore({
+        events: {
+          ...slice.getInitialState(),
+          eventsOffset: 50,
+          eventsHasFetchedAll: true,
+        },
+      });
+      const events = [{ salesForceId: 'event-1' }] as any;
+      mockedApi.getAllEvents.mockResolvedValue({ data: events } as any);
+
+      store.dispatch(
+        actions.fetchEventsWithFilters(buildFilters({ search: 'gala' }))
+      );
+      await flushPromises();
+
+      expect(store.getState().events.eventsOffset).toBe(0);
+      expect(store.getState().events.events).toEqual(events);
+      expect(mockedApi.getAllEvents).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'gala', offset: 0 })
+      );
+    });
+  });
+
+  describe('fetchEventsNextPage', () => {
+    it('fetches the next page when not all events were fetched and no fetch is in flight', async () => {
+      const store = createTestStore({
+        events: {
+          ...slice.getInitialState(),
+          eventsHasFetchedAll: false,
+        },
+      });
+      mockedApi.getAllEvents.mockResolvedValue({ data: [] } as any);
+
+      store.dispatch(actions.fetchEventsNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllEvents).toHaveBeenCalled();
+    });
+
+    it('does nothing when all events have already been fetched', async () => {
+      const store = createTestStore({
+        events: {
+          ...slice.getInitialState(),
+          eventsHasFetchedAll: true,
+        },
+      });
+
+      store.dispatch(actions.fetchEventsNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllEvents).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when a fetch is already in flight', async () => {
+      const store = createTestStore({
+        events: {
+          ...slice.getInitialState(),
+          eventsHasFetchedAll: false,
+          fetchEvents: { status: 'REQUESTED' as any },
+        },
+      });
+
+      store.dispatch(actions.fetchEventsNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllEvents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchSelectedEventRequested', () => {
+    it('stores the selected event on success', async () => {
+      const store = createTestStore();
+      const event = { salesForceId: 'event-1' } as any;
+      mockedApi.getEvent.mockResolvedValue({ data: event } as any);
+
+      store.dispatch(
+        actions.fetchSelectedEventRequested({ eventId: 'event-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().events.selectedEvent).toEqual(event);
+      expect(store.getState().events.fetchSelectedEvent.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('dispatches fetchSelectedEventFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getEvent.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.fetchSelectedEventRequested({ eventId: 'event-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().events.fetchSelectedEvent.status).toBe('FAILED');
+    });
+  });
+
+  describe('fetchSelectedEventParticipantsRequested', () => {
+    it('sets the participants on the selected event on success', async () => {
+      const store = createTestStore({
+        events: {
+          ...slice.getInitialState(),
+          selectedEvent: { salesForceId: 'event-1', participants: [] } as any,
+        },
+      });
+      const participants = [{ id: 'user-1' }] as any;
+      mockedApi.getEventParticipants.mockResolvedValue({
+        data: participants,
+      } as any);
+
+      store.dispatch(
+        actions.fetchSelectedEventParticipantsRequested({ eventId: 'event-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().events.selectedEvent?.participants).toEqual(
+        participants
+      );
+      expect(
+        store.getState().events.fetchSelectedEventParticipants.status
+      ).toBe('SUCCEEDED');
+    });
+
+    it('dispatches fetchSelectedEventParticipantsFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getEventParticipants.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.fetchSelectedEventParticipantsRequested({ eventId: 'event-1' })
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().events.fetchSelectedEventParticipants.status
+      ).toBe('FAILED');
+    });
+  });
+
+  describe('updateUserParticipationRequested', () => {
+    it('updates isParticipating and re-fetches the participants list on success', async () => {
+      const store = createTestStore({
+        events: {
+          ...slice.getInitialState(),
+          selectedEvent: {
+            salesForceId: 'event-1',
+            isParticipating: false,
+            participants: [],
+          } as any,
+        },
+      });
+      mockedApi.updateEventParticipation.mockResolvedValue({} as any);
+      const participants = [{ id: 'user-1' }] as any;
+      mockedApi.getEventParticipants.mockResolvedValue({
+        data: participants,
+      } as any);
+
+      store.dispatch(
+        actions.updateUserParticipationRequested({
+          eventSalesForceId: 'event-1',
+          isParticipating: true,
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().events.updateUserParticipation.status).toBe(
+        'SUCCEEDED'
+      );
+      expect(store.getState().events.selectedEvent?.isParticipating).toBe(true);
+      expect(store.getState().events.selectedEvent?.participants).toEqual(
+        participants
+      );
+    });
+
+    it('dispatches updateUserParticipationFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.updateEventParticipation.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateUserParticipationRequested({
+          eventSalesForceId: 'event-1',
+          isParticipating: true,
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().events.updateUserParticipation.status).toBe(
+        'FAILED'
+      );
+      expect(mockedApi.getEventParticipants).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/use-cases/events/events.selectors.spec.ts
+++ b/src/use-cases/events/events.selectors.spec.ts
@@ -1,0 +1,97 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { EventWithParticipants } from '@/src/api/types';
+import {
+  fetchEventsSelectors,
+  fetchSelectedEventParticipantsSelectors,
+  fetchSelectedEventSelectors,
+  selectEvents,
+  selectEventsHasFetchedAll,
+  selectEventsOffset,
+  selectSelectedEvent,
+  updateUserParticipationSelectors,
+} from './events.selectors';
+import { RootState, slice } from './events.slice';
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    events: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('events.selectors', () => {
+  describe('selectEvents', () => {
+    it('returns the events list', () => {
+      const events = [{ salesForceId: 'event-1' }] as any;
+      expect(selectEvents(buildState({ events }))).toEqual(events);
+    });
+  });
+
+  describe('selectEventsOffset', () => {
+    it('returns the events offset', () => {
+      expect(selectEventsOffset(buildState({ eventsOffset: 25 }))).toBe(25);
+    });
+  });
+
+  describe('selectEventsHasFetchedAll', () => {
+    it('returns the eventsHasFetchedAll flag', () => {
+      expect(
+        selectEventsHasFetchedAll(buildState({ eventsHasFetchedAll: true }))
+      ).toBe(true);
+      expect(
+        selectEventsHasFetchedAll(buildState({ eventsHasFetchedAll: false }))
+      ).toBe(false);
+    });
+  });
+
+  describe('selectSelectedEvent', () => {
+    it('returns the selected event', () => {
+      const selectedEvent = {
+        salesForceId: 'event-1',
+      } as EventWithParticipants;
+      expect(selectSelectedEvent(buildState({ selectedEvent }))).toEqual(
+        selectedEvent
+      );
+    });
+
+    it('returns null when there is no selected event', () => {
+      expect(selectSelectedEvent(buildState())).toBeNull();
+    });
+  });
+
+  const statusSelectors: [string, (state: RootState) => string, string][] = [
+    [
+      'fetchEventsSelectors.selectFetchEventsStatus',
+      fetchEventsSelectors.selectFetchEventsStatus,
+      'fetchEvents',
+    ],
+    [
+      'fetchSelectedEventSelectors.selectFetchSelectedEventStatus',
+      fetchSelectedEventSelectors.selectFetchSelectedEventStatus,
+      'fetchSelectedEvent',
+    ],
+    [
+      'fetchSelectedEventParticipantsSelectors.selectFetchSelectedEventParticipantsStatus',
+      fetchSelectedEventParticipantsSelectors.selectFetchSelectedEventParticipantsStatus,
+      'fetchSelectedEventParticipants',
+    ],
+    [
+      'updateUserParticipationSelectors.selectUpdateUserParticipationStatus',
+      updateUserParticipationSelectors.selectUpdateUserParticipationStatus,
+      'updateUserParticipation',
+    ],
+  ];
+
+  statusSelectors.forEach(([name, selector, stateKey]) => {
+    describe(name, () => {
+      it(`reads the status from events.${stateKey}`, () => {
+        const state = buildState({
+          [stateKey]: { status: 'SUCCEEDED' },
+        } as any);
+
+        expect(selector(state)).toBe('SUCCEEDED');
+      });
+    });
+  });
+});

--- a/src/use-cases/events/events.slice.spec.ts
+++ b/src/use-cases/events/events.slice.spec.ts
@@ -1,0 +1,230 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { Event, EventWithParticipants } from '@/src/api/types';
+import { EVENTS_LIMIT, ReduxRequestEvents } from '@/src/constants';
+import {
+  EventMode,
+  EventType,
+  PublicSensibilise,
+} from '@/src/constants/events';
+import { slice } from './events.slice';
+
+const { actions, reducer } = slice;
+
+const buildEvent = (overrides: Partial<Event> = {}): Event =>
+  ({
+    salesForceId: 'event-1',
+    name: 'Welcome session',
+    description: 'A great event',
+    startDate: '2026-01-01T10:00:00Z',
+    endDate: '2026-01-01T12:00:00Z',
+    eventType: EventType.WELCOME_SESSION,
+    participantsCount: 0,
+    registrationCount: 0,
+    mode: EventMode.ONLINE,
+    meetingLink: null,
+    fullAddress: null,
+    duration: null,
+    format: 'format',
+    goal: 'goal',
+    audience: 'audience',
+    isParticipating: false,
+    publicSensibilise: [PublicSensibilise.GENERAL_PUBLIC],
+    ...overrides,
+  }) as Event;
+
+const buildEventWithParticipants = (
+  overrides: Partial<EventWithParticipants> = {}
+): EventWithParticipants =>
+  ({
+    ...buildEvent(),
+    participants: [],
+    ...overrides,
+  }) as EventWithParticipants;
+
+describe('events slice', () => {
+  describe('fetchEventsSucceeded', () => {
+    it('replaces the events list when offset is 0', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        eventsOffset: 0,
+        events: [buildEvent({ salesForceId: 'stale' })],
+      };
+      const events = [buildEvent({ salesForceId: 'event-1' })];
+
+      const state = reducer(initialState, actions.fetchEventsSucceeded(events));
+
+      expect(state.events).toEqual(events);
+    });
+
+    it('appends to the events list when offset is greater than 0', () => {
+      const existing = [buildEvent({ salesForceId: 'event-1' })];
+      const initialState = {
+        ...slice.getInitialState(),
+        eventsOffset: EVENTS_LIMIT,
+        events: existing,
+      };
+      const nextPage = [buildEvent({ salesForceId: 'event-2' })];
+
+      const state = reducer(
+        initialState,
+        actions.fetchEventsSucceeded(nextPage)
+      );
+
+      expect(state.events).toEqual([...existing, ...nextPage]);
+    });
+
+    it('marks eventsHasFetchedAll true when the page is smaller than the limit', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchEventsSucceeded([buildEvent()])
+      );
+
+      expect(state.eventsHasFetchedAll).toBe(true);
+    });
+
+    it('marks eventsHasFetchedAll false when the page is full', () => {
+      const fullPage = Array.from({ length: EVENTS_LIMIT }, (_, i) =>
+        buildEvent({ salesForceId: `event-${i}` })
+      );
+
+      const state = reducer(undefined, actions.fetchEventsSucceeded(fullPage));
+
+      expect(state.eventsHasFetchedAll).toBe(false);
+    });
+  });
+
+  it('fetchSelectedEventSucceeded sets selectedEvent', () => {
+    const event = buildEventWithParticipants();
+
+    const state = reducer(
+      undefined,
+      actions.fetchSelectedEventSucceeded(event)
+    );
+
+    expect(state.selectedEvent).toEqual(event);
+  });
+
+  describe('updateUserParticipationSucceeded', () => {
+    it('sets isParticipating on the selected event', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedEvent: buildEventWithParticipants({ isParticipating: false }),
+      };
+
+      const state = reducer(
+        initialState,
+        actions.updateUserParticipationSucceeded({ isParticipating: true })
+      );
+
+      expect(state.selectedEvent?.isParticipating).toBe(true);
+    });
+
+    it('is a no-op when there is no selected event', () => {
+      const state = reducer(
+        undefined,
+        actions.updateUserParticipationSucceeded({ isParticipating: true })
+      );
+
+      expect(state.selectedEvent).toBeNull();
+    });
+  });
+
+  describe('fetchSelectedEventParticipantsSucceeded', () => {
+    it('sets participants on the selected event', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedEvent: buildEventWithParticipants({ participants: [] }),
+      };
+      const participants = [
+        {
+          id: 'user-1',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          role: 'COACH',
+          userProfile: { hasPicture: true },
+        },
+      ] as any as EventWithParticipants['participants'];
+
+      const state = reducer(
+        initialState,
+        actions.fetchSelectedEventParticipantsSucceeded(participants)
+      );
+
+      expect(state.selectedEvent?.participants).toEqual(participants);
+    });
+
+    it('is a no-op when there is no selected event', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchSelectedEventParticipantsSucceeded([])
+      );
+
+      expect(state.selectedEvent).toBeNull();
+    });
+  });
+
+  it('resetEventsOffset resets pagination state', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      eventsOffset: EVENTS_LIMIT * 2,
+      eventsHasFetchedAll: true,
+      events: [buildEvent()],
+    };
+
+    const state = reducer(initialState, actions.resetEventsOffset());
+
+    expect(state.eventsOffset).toBe(0);
+    expect(state.eventsHasFetchedAll).toBe(false);
+    expect(state.events).toEqual([]);
+  });
+
+  it('fetchEventsWithFilters does not mutate state', () => {
+    const initialState = slice.getInitialState();
+
+    const state = reducer(initialState, actions.fetchEventsWithFilters({}));
+
+    expect(state).toEqual(initialState);
+  });
+
+  describe('fetchEventsNextPage', () => {
+    it('increments the offset when not all events are fetched and the previous fetch succeeded', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        eventsOffset: 0,
+        eventsHasFetchedAll: false,
+        fetchEvents: { status: ReduxRequestEvents.SUCCEEDED },
+      };
+
+      const state = reducer(initialState, actions.fetchEventsNextPage({}));
+
+      expect(state.eventsOffset).toBe(EVENTS_LIMIT);
+    });
+
+    it('does not increment the offset when all events are already fetched', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        eventsOffset: 0,
+        eventsHasFetchedAll: true,
+        fetchEvents: { status: ReduxRequestEvents.SUCCEEDED },
+      };
+
+      const state = reducer(initialState, actions.fetchEventsNextPage({}));
+
+      expect(state.eventsOffset).toBe(0);
+    });
+
+    it('does not increment the offset when a fetch is still in progress', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        eventsOffset: 0,
+        eventsHasFetchedAll: false,
+        fetchEvents: { status: ReduxRequestEvents.REQUESTED },
+      };
+
+      const state = reducer(initialState, actions.fetchEventsNextPage({}));
+
+      expect(state.eventsOffset).toBe(0);
+    });
+  });
+});

--- a/src/use-cases/events/events.thunks.spec.ts
+++ b/src/use-cases/events/events.thunks.spec.ts
@@ -1,0 +1,71 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { updateUserParticipationThunk } from './events.thunks';
+
+const mockedApi = getMockedApi();
+
+describe('events thunks', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('updateUserParticipationThunk', () => {
+    it('fulfills with the API response payload on success', async () => {
+      const store = createTestStore();
+      const data = { isParticipating: true };
+      mockedApi.updateEventParticipation.mockResolvedValue({ data } as any);
+
+      const resultAction = await store.dispatch(
+        updateUserParticipationThunk({
+          eventSalesForceId: 'event-1',
+          isParticipating: true,
+        }) as any
+      );
+
+      expect(resultAction.type).toBe(
+        'events/updateUserParticipation/fulfilled'
+      );
+      expect(resultAction.payload).toEqual(data);
+      expect(mockedApi.updateEventParticipation).toHaveBeenCalledWith(
+        'event-1',
+        true
+      );
+    });
+
+    it('rejects with the error message when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.updateEventParticipation.mockRejectedValue(
+        new Error('network error')
+      );
+
+      const resultAction = await store.dispatch(
+        updateUserParticipationThunk({
+          eventSalesForceId: 'event-1',
+          isParticipating: true,
+        }) as any
+      );
+
+      expect(resultAction.type).toBe('events/updateUserParticipation/rejected');
+      expect(resultAction.payload).toBe('network error');
+    });
+
+    it('rejects with a fallback message when the error has no message', async () => {
+      const store = createTestStore();
+      mockedApi.updateEventParticipation.mockRejectedValue({});
+
+      const resultAction = await store.dispatch(
+        updateUserParticipationThunk({
+          eventSalesForceId: 'event-1',
+          isParticipating: true,
+        }) as any
+      );
+
+      expect(resultAction.type).toBe('events/updateUserParticipation/rejected');
+      expect(resultAction.payload).toBe('Erreur inconnue');
+    });
+  });
+});

--- a/src/use-cases/gamification/gamification.saga.spec.ts
+++ b/src/use-cases/gamification/gamification.saga.spec.ts
@@ -1,0 +1,153 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { AchievementProgressionEntry, AchievementType } from '@/src/api/types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice as messagingSlice } from '@/src/use-cases/messaging/messaging.slice';
+import { slice } from './gamification.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildEntry = (
+  overrides: Partial<AchievementProgressionEntry> = {}
+): AchievementProgressionEntry => ({
+  type: AchievementType.SUPER_ENGAGED_COACH,
+  label: 'Coach engagé',
+  hasAchievement: false,
+  achievedAt: null,
+  expireAt: null,
+  statsWindowMonths: 6,
+  criteria: [
+    {
+      key: 'messages-sent',
+      label: 'Messages envoyés',
+      currentValue: 1,
+      threshold: 10,
+    },
+  ],
+  ...overrides,
+});
+
+describe('gamification saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchAchievementProgressionInitial', () => {
+    it('fetches the progressions and stores them as the baseline without queuing a modal', async () => {
+      const store = createTestStore();
+      const entries = [buildEntry({ hasAchievement: true })];
+      mockedApi.getAchievementProgression.mockResolvedValue({
+        data: entries,
+      } as any);
+
+      store.dispatch(actions.fetchAchievementProgressionInitial());
+      await flushPromises();
+
+      expect(store.getState().gamification.achievementProgressions).toEqual(
+        entries
+      );
+      expect(store.getState().gamification.isInitialized).toBe(true);
+      expect(
+        store.getState().gamification.achievementProgressionToShow
+      ).toBeNull();
+    });
+
+    it('silently ignores API failures', async () => {
+      const store = createTestStore();
+      mockedApi.getAchievementProgression.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchAchievementProgressionInitial());
+      await flushPromises();
+
+      expect(store.getState().gamification.isInitialized).toBe(false);
+      expect(store.getState().gamification.achievementProgressions).toEqual([]);
+    });
+  });
+
+  describe('messaging postMessageSucceeded (cross-domain)', () => {
+    function dispatchPostMessageSucceeded(
+      store: ReturnType<typeof createTestStore>
+    ) {
+      store.dispatch(
+        messagingSlice.actions.postMessageSucceeded({
+          message: {
+            id: 'message-1',
+            authorId: 'user-1',
+            createdAt: '2026-01-01T00:00:00.000Z',
+            conversation: { id: 'conversation-1' },
+          } as any,
+          isNewConversation: true,
+        })
+      );
+    }
+
+    it('re-fetches progressions and queues a modal when a criterion increased since the baseline', async () => {
+      const store = createTestStore();
+      const baseline = [
+        buildEntry({
+          criteria: [
+            {
+              key: 'messages-sent',
+              label: 'Messages envoyés',
+              currentValue: 1,
+              threshold: 10,
+            },
+          ],
+        }),
+      ];
+      mockedApi.getAchievementProgression.mockResolvedValue({
+        data: baseline,
+      } as any);
+      store.dispatch(actions.fetchAchievementProgressionInitial());
+      await flushPromises();
+
+      const updated = [
+        buildEntry({
+          criteria: [
+            {
+              key: 'messages-sent',
+              label: 'Messages envoyés',
+              currentValue: 2,
+              threshold: 10,
+            },
+          ],
+        }),
+      ];
+      mockedApi.getAchievementProgression.mockResolvedValue({
+        data: updated,
+      } as any);
+
+      dispatchPostMessageSucceeded(store);
+      await flushPromises();
+
+      expect(store.getState().gamification.achievementProgressions).toEqual(
+        updated
+      );
+      expect(
+        store.getState().gamification.achievementProgressionToShow
+      ).toEqual({
+        entry: updated[0],
+        changedCriterionKey: 'messages-sent',
+      });
+    });
+
+    it('silently ignores API failures triggered after a message is sent', async () => {
+      const store = createTestStore();
+      mockedApi.getAchievementProgression.mockRejectedValue(new Error('boom'));
+
+      dispatchPostMessageSucceeded(store);
+      await flushPromises();
+
+      expect(store.getState().gamification.achievementProgressions).toEqual([]);
+      expect(
+        store.getState().gamification.achievementProgressionToShow
+      ).toBeNull();
+    });
+  });
+});

--- a/src/use-cases/gamification/gamification.selectors.spec.ts
+++ b/src/use-cases/gamification/gamification.selectors.spec.ts
@@ -1,0 +1,75 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { AchievementProgressionEntry, AchievementType } from '@/src/api/types';
+import {
+  selectAchievementProgressionToShow,
+  selectAchievementProgressions,
+  selectGamificationIsInitialized,
+} from './gamification.selectors';
+import { RootState, slice } from './gamification.slice';
+
+const buildEntry = (
+  overrides: Partial<AchievementProgressionEntry> = {}
+): AchievementProgressionEntry => ({
+  type: AchievementType.SUPER_ENGAGED_COACH,
+  label: 'Coach engagé',
+  hasAchievement: false,
+  achievedAt: null,
+  expireAt: null,
+  statsWindowMonths: 6,
+  criteria: [],
+  ...overrides,
+});
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    gamification: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('gamification.selectors', () => {
+  describe('selectAchievementProgressionToShow', () => {
+    it('returns the queued progression to show', () => {
+      const achievementProgressionToShow = {
+        entry: buildEntry(),
+        changedCriterionKey: 'messages-sent',
+      };
+
+      expect(
+        selectAchievementProgressionToShow(
+          buildState({ achievementProgressionToShow })
+        )
+      ).toEqual(achievementProgressionToShow);
+    });
+
+    it('returns null when there is nothing queued', () => {
+      expect(selectAchievementProgressionToShow(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectAchievementProgressions', () => {
+    it('returns the stored achievement progressions', () => {
+      const achievementProgressions = [buildEntry()];
+
+      expect(
+        selectAchievementProgressions(buildState({ achievementProgressions }))
+      ).toEqual(achievementProgressions);
+    });
+
+    it('returns an empty array by default', () => {
+      expect(selectAchievementProgressions(buildState())).toEqual([]);
+    });
+  });
+
+  describe('selectGamificationIsInitialized', () => {
+    it('returns the isInitialized flag', () => {
+      expect(
+        selectGamificationIsInitialized(buildState({ isInitialized: true }))
+      ).toBe(true);
+      expect(
+        selectGamificationIsInitialized(buildState({ isInitialized: false }))
+      ).toBe(false);
+    });
+  });
+});

--- a/src/use-cases/gamification/gamification.slice.spec.ts
+++ b/src/use-cases/gamification/gamification.slice.spec.ts
@@ -1,0 +1,243 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import {
+  AchievementProgressionEntry,
+  AchievementType,
+  CriterionStat,
+} from '@/src/api/types';
+import { slice } from './gamification.slice';
+
+const { actions, reducer } = slice;
+
+const buildCriterion = (
+  overrides: Partial<CriterionStat> = {}
+): CriterionStat => ({
+  key: 'messages-sent',
+  label: 'Messages envoyés',
+  currentValue: 1,
+  threshold: 10,
+  ...overrides,
+});
+
+const buildEntry = (
+  overrides: Partial<AchievementProgressionEntry> = {}
+): AchievementProgressionEntry => ({
+  type: AchievementType.SUPER_ENGAGED_COACH,
+  label: 'Coach engagé',
+  hasAchievement: false,
+  achievedAt: null,
+  expireAt: null,
+  statsWindowMonths: 6,
+  criteria: [buildCriterion()],
+  ...overrides,
+});
+
+describe('gamification slice', () => {
+  describe('achievementProgressionsInitialized', () => {
+    it('stores the progressions as the baseline, marks initialized and does not queue a modal', () => {
+      const entries = [buildEntry()];
+
+      const state = reducer(
+        undefined,
+        actions.achievementProgressionsInitialized(entries)
+      );
+
+      expect(state.achievementProgressions).toEqual(entries);
+      expect(state.isInitialized).toBe(true);
+      expect(state.achievementProgressionToShow).toBeNull();
+    });
+
+    it('clears any previously queued modal', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressionToShow: {
+          entry: buildEntry(),
+          changedCriterionKey: null,
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.achievementProgressionsInitialized([])
+      );
+
+      expect(state.achievementProgressionToShow).toBeNull();
+    });
+  });
+
+  describe('achievementProgressionReceived', () => {
+    it('sets achievementProgressionToShow (changedCriterionKey null) when a badge is newly obtained (Cas 1)', () => {
+      const previousEntry = buildEntry({ hasAchievement: false });
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressions: [previousEntry],
+      };
+      const newEntry = buildEntry({ hasAchievement: true });
+
+      const state = reducer(
+        initialState,
+        actions.achievementProgressionReceived([newEntry])
+      );
+
+      expect(state.achievementProgressionToShow).toEqual({
+        entry: newEntry,
+        changedCriterionKey: null,
+      });
+    });
+
+    it('sets achievementProgressionToShow with the changed criterion key when a criterion value increased (Cas 2)', () => {
+      const previousEntry = buildEntry({
+        hasAchievement: false,
+        criteria: [buildCriterion({ key: 'messages-sent', currentValue: 1 })],
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressions: [previousEntry],
+      };
+      const newEntry = buildEntry({
+        hasAchievement: false,
+        criteria: [buildCriterion({ key: 'messages-sent', currentValue: 2 })],
+      });
+
+      const state = reducer(
+        initialState,
+        actions.achievementProgressionReceived([newEntry])
+      );
+
+      expect(state.achievementProgressionToShow).toEqual({
+        entry: newEntry,
+        changedCriterionKey: 'messages-sent',
+      });
+    });
+
+    it('does not queue a modal when the badge is already obtained and no criterion increased', () => {
+      const previousEntry = buildEntry({
+        hasAchievement: true,
+        criteria: [buildCriterion({ currentValue: 5 })],
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressions: [previousEntry],
+      };
+      const newEntry = buildEntry({
+        hasAchievement: true,
+        criteria: [buildCriterion({ currentValue: 5 })],
+      });
+
+      const state = reducer(
+        initialState,
+        actions.achievementProgressionReceived([newEntry])
+      );
+
+      expect(state.achievementProgressionToShow).toBeNull();
+    });
+
+    it('does not queue a modal when no criterion value increased', () => {
+      const previousEntry = buildEntry({
+        criteria: [buildCriterion({ currentValue: 5 })],
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressions: [previousEntry],
+      };
+      const newEntry = buildEntry({
+        criteria: [buildCriterion({ currentValue: 5 })],
+      });
+
+      const state = reducer(
+        initialState,
+        actions.achievementProgressionReceived([newEntry])
+      );
+
+      expect(state.achievementProgressionToShow).toBeNull();
+    });
+
+    it('ignores entries with no matching previous entry (skips the comparison)', () => {
+      const newEntry = buildEntry({ hasAchievement: true });
+
+      const state = reducer(
+        undefined,
+        actions.achievementProgressionReceived([newEntry])
+      );
+
+      expect(state.achievementProgressionToShow).toBeNull();
+    });
+
+    it('stops at the first entry matching either case, in array order (does not scan ahead for a Cas 1 match)', () => {
+      const previousEntries = [
+        buildEntry({
+          type: AchievementType.SUPER_ENGAGED_COACH,
+          hasAchievement: false,
+          criteria: [buildCriterion({ key: 'a', currentValue: 1 })],
+        }),
+      ];
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressions: previousEntries,
+      };
+      // Only one AchievementType currently exists, so both entries share the
+      // same `type`; only the first one (by array order) can match a previous
+      // entry via `.find`. This asserts the loop breaks on the first entry
+      // whose own check succeeds, rather than continuing to look for a
+      // "more important" Cas 1 match later in the array.
+      const matchingCas2Entry = buildEntry({
+        hasAchievement: false,
+        criteria: [buildCriterion({ key: 'a', currentValue: 2 })],
+      });
+
+      const state = reducer(
+        initialState,
+        actions.achievementProgressionReceived([matchingCas2Entry])
+      );
+
+      expect(state.achievementProgressionToShow).toEqual({
+        entry: matchingCas2Entry,
+        changedCriterionKey: 'a',
+      });
+    });
+
+    it('replaces achievementProgressions with the new payload and marks initialized', () => {
+      const newEntries = [buildEntry()];
+
+      const state = reducer(
+        undefined,
+        actions.achievementProgressionReceived(newEntries)
+      );
+
+      expect(state.achievementProgressions).toEqual(newEntries);
+      expect(state.isInitialized).toBe(true);
+    });
+  });
+
+  describe('dismissAchievementProgressionModal', () => {
+    it('clears the queued modal', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        achievementProgressionToShow: {
+          entry: buildEntry(),
+          changedCriterionKey: null,
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.dismissAchievementProgressionModal()
+      );
+
+      expect(state.achievementProgressionToShow).toBeNull();
+    });
+  });
+
+  describe('fetchAchievementProgressionInitial', () => {
+    it('is a no-op reducer', () => {
+      const initialState = slice.getInitialState();
+
+      const state = reducer(
+        initialState,
+        actions.fetchAchievementProgressionInitial()
+      );
+
+      expect(state).toEqual(initialState);
+    });
+  });
+});

--- a/src/use-cases/messaging/messaging.saga.spec.ts
+++ b/src/use-cases/messaging/messaging.saga.spec.ts
@@ -1,0 +1,344 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { Conversation, ConversationType } from '@/src/api/types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice } from './messaging.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildConversation = (
+  overrides: Partial<Conversation> = {}
+): Conversation =>
+  ({
+    id: 'conversation-1',
+    type: ConversationType.DIRECT,
+    messages: [],
+    participants: [],
+    ...overrides,
+  }) as Conversation;
+
+describe('messaging saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getConversationsRequested', () => {
+    it('stores the fetched conversations on success', async () => {
+      const store = createTestStore();
+      const conversations = [buildConversation({ id: 'conv-1' })];
+      mockedApi.getConversations.mockResolvedValue({
+        data: conversations,
+      } as any);
+
+      store.dispatch(actions.getConversationsRequested());
+      await flushPromises();
+
+      expect(store.getState().messaging.conversations).toEqual(conversations);
+      expect(store.getState().messaging.getConversations.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('dispatches getConversationsFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getConversations.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.getConversationsRequested());
+      await flushPromises();
+
+      expect(store.getState().messaging.getConversations.status).toBe('FAILED');
+      expect(store.getState().messaging.conversations).toBeNull();
+    });
+  });
+
+  describe('getUnseenConversationsCountRequested', () => {
+    it('stores the unseen conversation count on success', async () => {
+      const store = createTestStore();
+      mockedApi.getUnseenConversationsCount.mockResolvedValue({
+        data: 3,
+      } as any);
+
+      store.dispatch(actions.getUnseenConversationsCountRequested());
+      await flushPromises();
+
+      expect(store.getState().messaging.unseenConversationCount).toBe(3);
+    });
+
+    it('dispatches getUnseenConversationsCountFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getUnseenConversationsCount.mockRejectedValue(
+        new Error('boom')
+      );
+
+      store.dispatch(actions.getUnseenConversationsCountRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().messaging.getUnseenConversationsCount.status
+      ).toBe('FAILED');
+    });
+  });
+
+  describe('getSelectedConversationRequested', () => {
+    it('fetches and stores the selected conversation when one is selected', async () => {
+      const store = createTestStore({
+        messaging: {
+          ...slice.getInitialState(),
+          selectedConversationId: 'conv-1',
+        },
+      });
+      const conversation = buildConversation({ id: 'conv-1' });
+      mockedApi.getConversationById.mockResolvedValue({
+        data: conversation,
+      } as any);
+
+      store.dispatch(actions.getSelectedConversationRequested());
+      await flushPromises();
+
+      expect(mockedApi.getConversationById).toHaveBeenCalledWith('conv-1');
+      expect(store.getState().messaging.selectedConversation).toEqual(
+        conversation
+      );
+      expect(store.getState().messaging.getSelectedConversation.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('dispatches getSelectedConversationFailed without calling the API when there is no selected conversation', async () => {
+      const store = createTestStore();
+
+      store.dispatch(actions.getSelectedConversationRequested());
+      await flushPromises();
+
+      expect(mockedApi.getConversationById).not.toHaveBeenCalled();
+      expect(store.getState().messaging.getSelectedConversation.status).toBe(
+        'FAILED'
+      );
+    });
+
+    it('dispatches getSelectedConversationFailed when the API call rejects', async () => {
+      const store = createTestStore({
+        messaging: {
+          ...slice.getInitialState(),
+          selectedConversationId: 'conv-1',
+        },
+      });
+      mockedApi.getConversationById.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.getSelectedConversationRequested());
+      await flushPromises();
+
+      expect(store.getState().messaging.getSelectedConversation.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+
+  describe('postMessageRequested', () => {
+    it('selects the newly created conversation when starting a new conversation', async () => {
+      const store = createTestStore();
+      const formData = new FormData();
+      const newConversation = buildConversation({ id: 'new-conv' });
+      mockedApi.postMessage.mockResolvedValue({
+        data: {
+          id: 'msg-1',
+          authorId: 'author-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          conversation: newConversation,
+        },
+      } as any);
+
+      store.dispatch(actions.postMessageRequested(formData));
+      await flushPromises();
+
+      expect(store.getState().messaging.selectedConversationId).toBe(
+        'new-conv'
+      );
+      expect(store.getState().messaging.postMessage.status).toBe('SUCCEEDED');
+    });
+
+    it('appends the message to the existing conversation and moves it to the top', async () => {
+      const author = {
+        id: 'author-1',
+        conversationParticipant: { seenAt: null },
+      } as any;
+      const targetConversation = buildConversation({
+        id: 'conv-2',
+        participants: [author],
+        messages: [],
+      });
+      const otherConversation = buildConversation({ id: 'conv-1' });
+      const store = createTestStore({
+        messaging: {
+          ...slice.getInitialState(),
+          conversations: [otherConversation, targetConversation],
+          selectedConversationId: 'conv-2',
+        },
+      });
+      const formData = new FormData();
+      formData.append('conversationId', 'conv-2');
+      mockedApi.postMessage.mockResolvedValue({
+        data: {
+          id: 'msg-1',
+          authorId: 'author-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+        },
+      } as any);
+
+      store.dispatch(actions.postMessageRequested(formData));
+      await flushPromises();
+
+      const { conversations } = store.getState().messaging;
+      expect(conversations?.map((c) => c.id)).toEqual(['conv-2', 'conv-1']);
+      expect(conversations?.[0].messages).toHaveLength(1);
+    });
+
+    it('dispatches postMessageFailed without notifying on a generic error', async () => {
+      const store = createTestStore();
+      mockedApi.postMessage.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.postMessageRequested(new FormData()));
+      await flushPromises();
+
+      expect(store.getState().messaging.postMessage.status).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(0);
+    });
+
+    it('notifies the user when the daily conversation limit is reached', async () => {
+      const store = createTestStore();
+      mockedApi.postMessage.mockRejectedValue({
+        isAxiosError: true,
+        response: {
+          status: 429,
+          data: { message: 'DAILY_CONVERSATION_LIMIT_REACHED' },
+        },
+      });
+
+      store.dispatch(actions.postMessageRequested(new FormData()));
+      await flushPromises();
+
+      expect(store.getState().messaging.postMessage.status).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+    });
+  });
+
+  describe('bindNewConversationRequested', () => {
+    it('fetches the conversations without creating a new one when no participant is required', async () => {
+      const store = createTestStore();
+      const conversations = [buildConversation({ id: 'conv-1' })];
+      mockedApi.getConversations.mockResolvedValue({
+        data: conversations,
+      } as any);
+
+      store.dispatch(actions.bindNewConversationRequested(''));
+      await flushPromises();
+
+      expect(store.getState().messaging.conversations).toEqual(conversations);
+      expect(mockedApi.getPublicUserProfile).not.toHaveBeenCalled();
+      expect(store.getState().messaging.selectedConversationId).toBeNull();
+    });
+
+    it('selects the existing direct conversation with the required participant', async () => {
+      const participant = {
+        id: 'user-42',
+        conversationParticipant: { seenAt: null },
+      } as any;
+      const existingConversation = buildConversation({
+        id: 'existing-conv',
+        type: ConversationType.DIRECT,
+        participants: [participant],
+      });
+      const store = createTestStore();
+      mockedApi.getConversations.mockResolvedValue({
+        data: [existingConversation],
+      } as any);
+      mockedApi.getPublicUserProfile.mockResolvedValue({
+        data: {
+          id: 'user-42',
+          firstName: 'Jane',
+          lastName: 'Doe',
+          role: 'CANDIDATE',
+        },
+      } as any);
+
+      store.dispatch(actions.bindNewConversationRequested('user-42'));
+      await flushPromises();
+
+      expect(store.getState().messaging.selectedConversationId).toBe(
+        'existing-conv'
+      );
+    });
+
+    it('creates a new conversation when the required participant has none yet', async () => {
+      const store = createTestStore();
+      mockedApi.getConversations.mockResolvedValue({ data: [] } as any);
+      mockedApi.getPublicUserProfile.mockResolvedValue({
+        data: {
+          id: 'user-99',
+          firstName: 'John',
+          lastName: 'Smith',
+          role: 'CANDIDATE',
+        },
+      } as any);
+
+      store.dispatch(actions.bindNewConversationRequested('user-99'));
+      await flushPromises();
+
+      expect(store.getState().messaging.selectedConversationId).toBe('new');
+      expect(
+        store.getState().messaging.selectedConversation?.participants[0].id
+      ).toBe('user-99');
+    });
+  });
+
+  describe('postFeedbackRequested', () => {
+    it('marks the selected conversation as not needing feedback on success', async () => {
+      const selectedConversation = buildConversation({
+        shouldGiveFeedback: true,
+      });
+      const store = createTestStore({
+        messaging: { ...slice.getInitialState(), selectedConversation },
+      });
+      mockedApi.postConversationFeedback.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.postFeedbackRequested({
+          conversationParticipantId: 'cp-1',
+          rating: 5,
+        })
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().messaging.selectedConversation?.shouldGiveFeedback
+      ).toBe(false);
+    });
+
+    it('leaves the selected conversation untouched when the API call rejects', async () => {
+      const selectedConversation = buildConversation({
+        shouldGiveFeedback: true,
+      });
+      const store = createTestStore({
+        messaging: { ...slice.getInitialState(), selectedConversation },
+      });
+      mockedApi.postConversationFeedback.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.postFeedbackRequested({
+          conversationParticipantId: 'cp-1',
+          rating: 5,
+        })
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().messaging.selectedConversation?.shouldGiveFeedback
+      ).toBe(true);
+    });
+  });
+});

--- a/src/use-cases/messaging/messaging.slice.spec.ts
+++ b/src/use-cases/messaging/messaging.slice.spec.ts
@@ -1,0 +1,370 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import {
+  Conversation,
+  ConversationParticipant,
+  ConversationType,
+  Message,
+  MessageWithConversation,
+} from '@/src/api/types';
+import { slice } from './messaging.slice';
+
+const { actions, reducer } = slice;
+
+const buildParticipant = (
+  overrides: Partial<ConversationParticipant> = {}
+): ConversationParticipant =>
+  ({
+    id: 'participant-1',
+    firstName: 'Jane',
+    lastName: 'Doe',
+    userProfile: null,
+    conversationParticipant: {
+      id: 'cp-1',
+      seenAt: '2020-01-01T00:00:00.000Z',
+      createdAt: '2020-01-01T00:00:00.000Z',
+      updatedAt: '2020-01-01T00:00:00.000Z',
+    },
+    ...overrides,
+  }) as ConversationParticipant;
+
+const buildMessage = (overrides: Partial<Message> = {}): Message =>
+  ({
+    id: `msg-${Math.random()}`,
+    content: 'Hello',
+    authorId: 'author-1',
+    createdAt: '2026-01-02T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    conversationId: 'conversation-1',
+    medias: [],
+    ...overrides,
+  }) as Message;
+
+const buildConversation = (
+  overrides: Partial<Conversation> = {}
+): Conversation =>
+  ({
+    id: 'conversation-1',
+    type: ConversationType.DIRECT,
+    messages: [],
+    participants: [],
+    ...overrides,
+  }) as Conversation;
+
+const buildMessageWithConversation = (
+  overrides: Partial<MessageWithConversation> = {}
+): MessageWithConversation =>
+  ({
+    ...buildMessage(),
+    conversation: buildConversation(),
+    ...overrides,
+  }) as MessageWithConversation;
+
+describe('messaging slice', () => {
+  describe('getConversationsSucceeded', () => {
+    it('stores the fetched conversations', () => {
+      const conversations = [buildConversation({ id: 'conv-1' })];
+
+      const state = reducer(
+        slice.getInitialState(),
+        actions.getConversationsSucceeded(conversations)
+      );
+
+      expect(state.conversations).toEqual(conversations);
+    });
+  });
+
+  describe('getUnseenConversationsCountSucceeded', () => {
+    it('stores the unseen conversation count', () => {
+      const state = reducer(
+        slice.getInitialState(),
+        actions.getUnseenConversationsCountSucceeded(5)
+      );
+
+      expect(state.unseenConversationCount).toBe(5);
+    });
+  });
+
+  describe('bindNewConversationSucceeded', () => {
+    it('selects the existing direct conversation when the required participant already has one', () => {
+      const existingParticipant = buildParticipant({ id: 'user-2' });
+      const existingConversation = buildConversation({
+        id: 'existing-conv',
+        type: ConversationType.DIRECT,
+        participants: [existingParticipant],
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: [existingConversation],
+        selectedConversationId: null,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.bindNewConversationSucceeded([
+          buildParticipant({ id: 'user-2' }),
+        ])
+      );
+
+      expect(state.selectedConversationId).toBe('existing-conv');
+      expect(state.selectedConversation).toBeNull();
+    });
+
+    it('creates a new direct conversation when there is a single required participant with no existing conversation', () => {
+      const participant = buildParticipant({ id: 'user-3' });
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: null,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.bindNewConversationSucceeded([participant])
+      );
+
+      expect(state.selectedConversationId).toBe('new');
+      expect(state.selectedConversation?.type).toBe(ConversationType.DIRECT);
+      expect(state.selectedConversation?.participants).toEqual([participant]);
+      expect(state.selectedConversation?.messages).toEqual([]);
+    });
+
+    it('creates a new group conversation when there are multiple required participants with no existing conversation', () => {
+      const participants = [
+        buildParticipant({ id: 'user-4' }),
+        buildParticipant({ id: 'user-5' }),
+      ];
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: [],
+      };
+
+      const state = reducer(
+        initialState,
+        actions.bindNewConversationSucceeded(participants)
+      );
+
+      expect(state.selectedConversationId).toBe('new');
+      expect(state.selectedConversation?.type).toBe(ConversationType.GROUP);
+      expect(state.selectedConversation?.participants).toEqual(participants);
+    });
+  });
+
+  describe('postMessageSucceeded', () => {
+    it('selects the new conversation and prepends it to the list when starting a new conversation', () => {
+      const existingConversation = buildConversation({ id: 'existing-conv' });
+      const newConversation = buildConversation({ id: 'new-conv' });
+      const message = buildMessageWithConversation({
+        conversation: newConversation,
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: [existingConversation],
+      };
+
+      const state = reducer(
+        initialState,
+        actions.postMessageSucceeded({ message, isNewConversation: true })
+      );
+
+      expect(state.selectedConversationId).toBe('new-conv');
+      expect(state.conversations).toHaveLength(2);
+      expect(state.conversations?.[0]).toEqual({
+        ...newConversation,
+        messages: [message],
+      });
+      expect(state.conversations?.[1]).toEqual(existingConversation);
+    });
+
+    it('selects the new conversation without touching the list when conversations have not loaded yet', () => {
+      const newConversation = buildConversation({ id: 'new-conv' });
+      const message = buildMessageWithConversation({
+        conversation: newConversation,
+      });
+      const initialState = { ...slice.getInitialState(), conversations: null };
+
+      const state = reducer(
+        initialState,
+        actions.postMessageSucceeded({ message, isNewConversation: true })
+      );
+
+      expect(state.selectedConversationId).toBe('new-conv');
+      expect(state.conversations).toBeNull();
+    });
+
+    it('appends the message, marks it seen for the author, and moves the conversation to the top', () => {
+      const author = buildParticipant({ id: 'author-1' });
+      const targetConversation = buildConversation({
+        id: 'conv-2',
+        participants: [author],
+        messages: [],
+      });
+      const otherConversation = buildConversation({ id: 'conv-1' });
+      const selectedConversation = buildConversation({
+        id: 'conv-2',
+        participants: [author],
+        messages: [],
+      });
+      const message = buildMessageWithConversation({
+        authorId: 'author-1',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        conversation: targetConversation,
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: [otherConversation, targetConversation],
+        selectedConversationId: 'conv-2',
+        selectedConversation,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.postMessageSucceeded({ message, isNewConversation: false })
+      );
+
+      expect(state.conversations?.map((c) => c.id)).toEqual([
+        'conv-2',
+        'conv-1',
+      ]);
+      expect(state.conversations?.[0].messages[0]).toEqual(message);
+      expect(
+        state.conversations?.[0].participants[0].conversationParticipant.seenAt
+      ).toBe('2026-05-01T00:00:00.000Z');
+      expect(state.selectedConversation?.messages[0]).toEqual(message);
+    });
+
+    it('is a no-op on the conversation list when conversations have not loaded yet for an existing conversation', () => {
+      const message = buildMessageWithConversation();
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: null,
+        selectedConversationId: 'conv-2',
+      };
+
+      const state = reducer(
+        initialState,
+        actions.postMessageSucceeded({ message, isNewConversation: false })
+      );
+
+      expect(state.conversations).toBeNull();
+    });
+  });
+
+  describe('getSelectedConversationSucceeded', () => {
+    it('sets the selected conversation and updates it within the conversation list', () => {
+      const oldVersion = buildConversation({ id: 'conv-1', messages: [] });
+      const updated = buildConversation({
+        id: 'conv-1',
+        messages: [buildMessage()],
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        conversations: [oldVersion],
+        selectedConversationId: 'conv-1',
+      };
+
+      const state = reducer(
+        initialState,
+        actions.getSelectedConversationSucceeded(updated)
+      );
+
+      expect(state.selectedConversation).toEqual(updated);
+      expect(state.conversations?.[0]).toEqual(updated);
+    });
+
+    it('sets the selected conversation without touching the list when conversations have not loaded yet', () => {
+      const updated = buildConversation({ id: 'conv-1' });
+      const initialState = { ...slice.getInitialState(), conversations: null };
+
+      const state = reducer(
+        initialState,
+        actions.getSelectedConversationSucceeded(updated)
+      );
+
+      expect(state.selectedConversation).toEqual(updated);
+      expect(state.conversations).toBeNull();
+    });
+  });
+
+  describe('plain reducers', () => {
+    it('selectConversation sets selectedConversationId', () => {
+      const state = reducer(
+        slice.getInitialState(),
+        actions.selectConversation('conv-1')
+      );
+
+      expect(state.selectedConversationId).toBe('conv-1');
+    });
+
+    it('setQuery sets query', () => {
+      const state = reducer(slice.getInitialState(), actions.setQuery('hi'));
+
+      expect(state.query).toBe('hi');
+    });
+
+    it('setPinnedInfo sets pinnedInfo', () => {
+      const state = reducer(
+        slice.getInitialState(),
+        actions.setPinnedInfo('ADDRESSEE_UNAVAILABLE')
+      );
+
+      expect(state.pinnedInfo).toBe('ADDRESSEE_UNAVAILABLE');
+    });
+
+    it('setNewMessage sets newMessage', () => {
+      const state = reducer(
+        slice.getInitialState(),
+        actions.setNewMessage('draft text')
+      );
+
+      expect(state.newMessage).toBe('draft text');
+    });
+
+    it('setIsAIPanelOpen sets isAIPanelOpen', () => {
+      const state = reducer(
+        slice.getInitialState(),
+        actions.setIsAIPanelOpen(true)
+      );
+
+      expect(state.isAIPanelOpen).toBe(true);
+    });
+
+    it('setActivePanelView sets the active view and opens the AI panel', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        isAIPanelOpen: false,
+      };
+
+      const state = reducer(initialState, actions.setActivePanelView('ai'));
+
+      expect(state.activePanelView).toBe('ai');
+      expect(state.isAIPanelOpen).toBe(true);
+    });
+  });
+
+  describe('postFeedbackSucceeded', () => {
+    it('marks the selected conversation as not needing feedback anymore', () => {
+      const selectedConversation = buildConversation({
+        shouldGiveFeedback: true,
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedConversation,
+      };
+
+      const state = reducer(initialState, actions.postFeedbackSucceeded());
+
+      expect(state.selectedConversation?.shouldGiveFeedback).toBe(false);
+    });
+
+    it('is a no-op when there is no selected conversation', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedConversation: null,
+      };
+
+      const state = reducer(initialState, actions.postFeedbackSucceeded());
+
+      expect(state.selectedConversation).toBeNull();
+    });
+  });
+});

--- a/src/use-cases/notifications/notifications.saga.spec.ts
+++ b/src/use-cases/notifications/notifications.saga.spec.ts
@@ -1,0 +1,31 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { notificationsActions } from '.';
+
+describe('notifications saga', () => {
+  it('is a no-op passthrough: it never dispatches or mutates state on its own', async () => {
+    const store = createTestStore();
+
+    await flushPromises();
+
+    expect(store.getState().notifications.notifications).toEqual([]);
+  });
+
+  it('does not interfere with the notifications reducer handling actions directly', async () => {
+    const store = createTestStore();
+
+    store.dispatch(
+      notificationsActions.addNotification({
+        type: 'success',
+        message: 'Saved',
+      })
+    );
+    await flushPromises();
+
+    expect(store.getState().notifications.notifications).toHaveLength(1);
+  });
+});

--- a/src/use-cases/notifications/notifications.selectors.spec.ts
+++ b/src/use-cases/notifications/notifications.selectors.spec.ts
@@ -1,0 +1,29 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { selectNotifications } from './notifications.selectors';
+import { RootState, slice } from './notifications.slice';
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    notifications: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('notifications.selectors', () => {
+  describe('selectNotifications', () => {
+    it('returns an empty list by default', () => {
+      expect(selectNotifications(buildState())).toEqual([]);
+    });
+
+    it('returns the notifications list', () => {
+      const notifications = [
+        { id: 'notif-1', type: 'success' as const, message: 'Saved' },
+      ];
+
+      expect(selectNotifications(buildState({ notifications }))).toEqual(
+        notifications
+      );
+    });
+  });
+});

--- a/src/use-cases/notifications/notifications.slice.spec.ts
+++ b/src/use-cases/notifications/notifications.slice.spec.ts
@@ -1,0 +1,80 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { slice } from './notifications.slice';
+
+const { actions, reducer } = slice;
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+describe('notifications slice', () => {
+  it('starts with an empty notifications list', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual({
+      notifications: [],
+    });
+  });
+
+  describe('addNotification', () => {
+    it('adds a notification with a generated id', () => {
+      const state = reducer(
+        undefined,
+        actions.addNotification({ type: 'success', message: 'Saved' })
+      );
+
+      expect(state.notifications).toHaveLength(1);
+      expect(state.notifications[0]).toMatchObject({
+        type: 'success',
+        message: 'Saved',
+      });
+      expect(state.notifications[0].id).toMatch(UUID_REGEX);
+    });
+
+    it('accumulates multiple notifications, each with its own id', () => {
+      let state = reducer(
+        undefined,
+        actions.addNotification({ type: 'success', message: 'First' })
+      );
+      state = reducer(
+        state,
+        actions.addNotification({ type: 'danger', message: 'Second' })
+      );
+
+      expect(state.notifications).toHaveLength(2);
+      expect(state.notifications[0]).toMatchObject({ message: 'First' });
+      expect(state.notifications[1]).toMatchObject({ message: 'Second' });
+      expect(state.notifications[0].id).not.toBe(state.notifications[1].id);
+    });
+  });
+
+  describe('removeNotification', () => {
+    it('removes the notification matching the given id', () => {
+      let state = reducer(
+        undefined,
+        actions.addNotification({ type: 'success', message: 'First' })
+      );
+      state = reducer(
+        state,
+        actions.addNotification({ type: 'danger', message: 'Second' })
+      );
+      const [first, second] = state.notifications;
+
+      state = reducer(state, actions.removeNotification({ id: first.id }));
+
+      expect(state.notifications).toEqual([second]);
+    });
+
+    it('is a no-op when no notification matches the given id', () => {
+      const state = reducer(
+        undefined,
+        actions.addNotification({ type: 'success', message: 'First' })
+      );
+
+      const nextState = reducer(
+        state,
+        actions.removeNotification({ id: 'unknown-id' })
+      );
+
+      expect(nextState.notifications).toEqual(state.notifications);
+    });
+  });
+});

--- a/src/use-cases/onboarding/onboarding.selectors.spec.ts
+++ b/src/use-cases/onboarding/onboarding.selectors.spec.ts
@@ -1,0 +1,42 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import {
+  selectFormErrorMessage,
+  selectWebinarSfId,
+} from './onboarding.selectors';
+import { RootState, slice } from './onboarding.slice';
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    onboarding: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('onboarding.selectors', () => {
+  describe('selectWebinarSfId', () => {
+    it('returns the webinar Salesforce id', () => {
+      expect(selectWebinarSfId(buildState({ webinarSfId: 'sf-id-1' }))).toBe(
+        'sf-id-1'
+      );
+    });
+
+    it('returns null when there is no webinar Salesforce id', () => {
+      expect(selectWebinarSfId(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectFormErrorMessage', () => {
+    it('returns the form error message', () => {
+      expect(
+        selectFormErrorMessage(
+          buildState({ formErrorMessage: 'Une erreur est survenue' })
+        )
+      ).toBe('Une erreur est survenue');
+    });
+
+    it('returns null when there is no form error message', () => {
+      expect(selectFormErrorMessage(buildState())).toBeNull();
+    });
+  });
+});

--- a/src/use-cases/onboarding/onboarding.slice.spec.ts
+++ b/src/use-cases/onboarding/onboarding.slice.spec.ts
@@ -1,0 +1,53 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { slice } from './onboarding.slice';
+
+const { actions, reducer } = slice;
+
+describe('onboarding slice', () => {
+  it('returns the initial state', () => {
+    const state = reducer(undefined, { type: '@@INIT' });
+
+    expect(state).toEqual({
+      webinarSfId: null,
+      formErrorMessage: null,
+    });
+  });
+
+  it('setWebinarSfId sets webinarSfId', () => {
+    const state = reducer(undefined, actions.setWebinarSfId('sf-id-1'));
+
+    expect(state.webinarSfId).toBe('sf-id-1');
+  });
+
+  it('setWebinarSfId can reset webinarSfId to null', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      webinarSfId: 'sf-id-1',
+    };
+
+    const state = reducer(initialState, actions.setWebinarSfId(null));
+
+    expect(state.webinarSfId).toBeNull();
+  });
+
+  it('setFormErrorMessage sets formErrorMessage', () => {
+    const state = reducer(
+      undefined,
+      actions.setFormErrorMessage('Une erreur est survenue')
+    );
+
+    expect(state.formErrorMessage).toBe('Une erreur est survenue');
+  });
+
+  it('setFormErrorMessage can reset formErrorMessage to null', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      formErrorMessage: 'Une erreur est survenue',
+    };
+
+    const state = reducer(initialState, actions.setFormErrorMessage(null));
+
+    expect(state.formErrorMessage).toBeNull();
+  });
+});

--- a/src/use-cases/onboardingOld/onboarding.saga.spec.ts
+++ b/src/use-cases/onboardingOld/onboarding.saga.spec.ts
@@ -1,0 +1,348 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { User } from '@/src/api/types';
+import { DocumentNames } from '@/src/constants';
+import { CompanyGoal } from '@/src/constants/company';
+import { OnboardingFlow } from '@/src/features/backoffice/onboardingLegacy/Onboarding.types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
+import { slice as currentUserSlice } from '@/src/use-cases/current-user/current-user.slice';
+import { slice } from './onboarding.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildUser = (overrides: Partial<User> = {}): User =>
+  ({
+    id: 'user-1',
+    email: 'user@example.com',
+    betaFeatures: {},
+    ...overrides,
+  }) as User;
+
+/**
+ * `launchOnboardingSaga` and `sendStepDataOnboardingSaga` both read
+ * `selectAuthenticatedUser` outside of any try/catch, so an authenticated
+ * user must always be preloaded before dispatching their triggering actions.
+ */
+function buildAuthenticatedStore(
+  onboardingOverrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+) {
+  seedAccessToken('token-123');
+  return createTestStore({
+    currentUser: { ...currentUserSlice.getInitialState(), user: buildUser() },
+    onboardingOld: { ...slice.getInitialState(), ...onboardingOverrides },
+  });
+}
+
+describe('onboardingOld saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('launchOnboarding', () => {
+    it('sets the flow and moves to the first not-skippable step', async () => {
+      const store = buildAuthenticatedStore();
+
+      store.dispatch(actions.launchOnboarding(OnboardingFlow.COMPANY));
+      await flushPromises();
+
+      expect(store.getState().onboardingOld.onboardingFlow).toBe(
+        OnboardingFlow.COMPANY
+      );
+      // Step 1 (ethics charter) is not skipped by default since no document
+      // has been read yet.
+      expect(store.getState().onboardingOld.currentStep).toBe(1);
+      expect(store.getState().onboardingOld.isLoading).toBe(false);
+    });
+
+    it('does not move to a step when the onboarding flow is not defined', async () => {
+      const store = buildAuthenticatedStore();
+
+      store.dispatch(actions.launchOnboarding(undefined as any));
+      await flushPromises();
+
+      expect(store.getState().onboardingOld.currentStep).toBe(0);
+    });
+  });
+
+  describe('setOnboardingStep', () => {
+    it('sets isLoading to false once the step has changed', async () => {
+      const store = buildAuthenticatedStore();
+
+      store.dispatch(actions.setOnboardingStep(2));
+      await flushPromises();
+
+      expect(store.getState().onboardingOld.currentStep).toBe(2);
+      expect(store.getState().onboardingOld.isLoading).toBe(false);
+    });
+  });
+
+  describe('setOnboardingCurrentStepData -> sendStepData', () => {
+    it('calls postReadDocument when the ethics charter step accepts it, then moves to the next step', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 1,
+      });
+      mockedApi.postReadDocument.mockReturnValue(undefined as any);
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({
+          hasAcceptedEthicsCharter: true,
+        } as any)
+      );
+      await flushPromises();
+
+      expect(mockedApi.postReadDocument).toHaveBeenCalledWith(
+        { documentName: DocumentNames.CharteEthique },
+        'user-1'
+      );
+      // Step 2 (company goal) is not skipped by default since no company
+      // goal has been set yet.
+      expect(store.getState().onboardingOld.currentStep).toBe(2);
+      expect(store.getState().onboardingOld.isLoading).toBe(false);
+      expect(store.getState().onboardingOld.sendStepData.status).toBe(
+        'SUCCEEDED'
+      );
+    });
+
+    it('does not call postReadDocument when the ethics charter was not accepted', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 2,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(actions.setOnboardingCurrentStepData({ goal: [] } as any));
+      await flushPromises();
+
+      expect(mockedApi.postReadDocument).not.toHaveBeenCalled();
+    });
+
+    it('always extracts company fields and calls updateCompany, even on a non-company-info step', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 2,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({
+          goal: [CompanyGoal.RECRUIT],
+        } as any)
+      );
+      await flushPromises();
+
+      expect(mockedApi.updateCompany).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: CompanyGoal.RECRUIT })
+      );
+    });
+
+    it('sets goal to BOTH when more than one goal is selected', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 2,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({
+          goal: [CompanyGoal.RECRUIT, CompanyGoal.SENSIBILIZE],
+        } as any)
+      );
+      await flushPromises();
+
+      expect(mockedApi.updateCompany).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: CompanyGoal.BOTH })
+      );
+    });
+
+    it('leaves goal undefined when no goal is provided', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 2,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(actions.setOnboardingCurrentStepData({} as any));
+      await flushPromises();
+
+      expect(mockedApi.updateCompany).toHaveBeenCalledWith(
+        expect.objectContaining({ goal: undefined })
+      );
+    });
+
+    it('maps businessSectorIds and departmentId to their raw values', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 3,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({
+          description: 'A description',
+          businessSectorIds: [{ value: 'sector-1' }, { value: 'sector-2' }],
+          departmentId: { value: '75' },
+          url: 'https://acme.example.com',
+          linkedInUrl: 'https://linkedin.example.com/acme',
+          hiringUrl: 'https://acme.example.com/jobs',
+        } as any)
+      );
+      await flushPromises();
+
+      expect(mockedApi.updateCompany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: 'A description',
+          businessSectorIds: ['sector-1', 'sector-2'],
+          departmentId: '75',
+          url: 'https://acme.example.com',
+          linkedInUrl: 'https://linkedin.example.com/acme',
+          hiringUrl: 'https://acme.example.com/jobs',
+        })
+      );
+    });
+
+    it('uploads the logo when one is provided', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 3,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+      mockedApi.updateCompanyLogo.mockResolvedValue({} as any);
+      mockedApi.getCurrentIdentity.mockResolvedValue({
+        data: { id: 'user-1' },
+      } as any);
+      const logoFile = new File(['logo'], 'logo.png');
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({ logo: [logoFile] } as any)
+      );
+      await flushPromises();
+
+      expect(mockedApi.updateCompanyLogo).toHaveBeenCalledTimes(1);
+      const formData = mockedApi.updateCompanyLogo.mock.calls[0][0];
+      expect(formData.get('file')).toBe(logoFile);
+    });
+
+    it('does not upload a logo when none is provided', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 2,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(actions.setOnboardingCurrentStepData({} as any));
+      await flushPromises();
+
+      expect(mockedApi.updateCompanyLogo).not.toHaveBeenCalled();
+    });
+
+    it('ends the onboarding and refreshes the profile on the last step', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 3,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+      mockedApi.getCurrentProfileComplete.mockResolvedValue({
+        data: { id: 'profile-1' },
+      } as any);
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({
+          description: 'A description',
+        } as any)
+      );
+      await flushPromises();
+
+      expect(store.getState().onboardingOld.currentStep).toBe(0);
+      expect(store.getState().onboardingOld.data).toEqual({});
+      expect(store.getState().onboardingOld.shouldLaunchOnboarding).toBe(false);
+      expect(store.getState().onboardingOld.onboardingFlow).toBeNull();
+      expect(
+        store.getState().currentUser.fetchCurrentProfileComplete.status
+      ).toBe('SUCCEEDED');
+      expect(store.getState().currentUser.profileComplete).toEqual({
+        id: 'profile-1',
+      });
+    });
+
+    it('does not end the onboarding when a not-skippable step remains', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 1,
+      });
+      mockedApi.updateCompany.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.setOnboardingCurrentStepData({
+          hasAcceptedEthicsCharter: true,
+        } as any)
+      );
+      await flushPromises();
+
+      expect(store.getState().onboardingOld.currentStep).toBe(2);
+      expect(store.getState().onboardingOld.shouldLaunchOnboarding).toBe(true);
+      expect(
+        store.getState().currentUser.fetchCurrentProfileComplete.status
+      ).toBe('IDLE');
+    });
+
+    it('sets isLoading to false and stores the error when the API call rejects', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 2,
+      });
+      mockedApi.updateCompany.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.setOnboardingCurrentStepData({} as any));
+      await flushPromises();
+
+      expect(store.getState().onboardingOld.isLoading).toBe(false);
+      expect(store.getState().onboardingOld.sendStepDataError).toBe(
+        'NOT_SAVE_DATA'
+      );
+      expect(store.getState().onboardingOld.sendStepData.status).toBe('FAILED');
+      // The step must not have advanced on failure.
+      expect(store.getState().onboardingOld.currentStep).toBe(2);
+    });
+  });
+
+  describe('sendStepDataOnboardingRequested (dispatched directly, without prerequisite state)', () => {
+    it('does not transition past REQUESTED when the onboarding flow is not defined', async () => {
+      const store = buildAuthenticatedStore();
+
+      store.dispatch(actions.sendStepDataOnboardingRequested());
+      await flushPromises();
+
+      expect(mockedApi.updateCompany).not.toHaveBeenCalled();
+      expect(store.getState().onboardingOld.sendStepData.status).toBe(
+        'REQUESTED'
+      );
+    });
+
+    it('does not transition past REQUESTED when there is no step data for the current step and flow', async () => {
+      const store = buildAuthenticatedStore({
+        onboardingFlow: OnboardingFlow.COMPANY,
+        currentStep: 1,
+      });
+
+      store.dispatch(actions.sendStepDataOnboardingRequested());
+      await flushPromises();
+
+      expect(mockedApi.updateCompany).not.toHaveBeenCalled();
+      expect(store.getState().onboardingOld.sendStepData.status).toBe(
+        'REQUESTED'
+      );
+    });
+  });
+});

--- a/src/use-cases/onboardingOld/onboarding.selectors.spec.ts
+++ b/src/use-cases/onboardingOld/onboarding.selectors.spec.ts
@@ -1,0 +1,242 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { OnboardingFlow } from '@/src/features/backoffice/onboardingLegacy/Onboarding.types';
+
+// Only `getOnboardingStepContent` is overridden here so the selectors under
+// test can be exercised against controlled step content (the real
+// `CompanyOnboardingStepContents` has no step with `dependsOn`, so the
+// `selectOnboardingDataFromOtherStep` reduce branch is otherwise unreachable
+// in this domain). `flattenOnboardingDataByFlow` is kept real since it's the
+// actual logic `selectOnboardingDataFromOtherStep` relies on.
+jest.mock('./onboarding.utils', () => {
+  const actual = jest.requireActual('./onboarding.utils');
+  return {
+    ...actual,
+    getOnboardingStepContent: jest.fn(),
+  };
+});
+
+import {
+  selectIsOnboardingLoading,
+  selectOnboardingCurrentStep,
+  selectOnboardingCurrentStepContent,
+  selectOnboardingCurrentStepData,
+  selectOnboardingData,
+  selectOnboardingDataFromOtherStep,
+  selectOnboardingFlow,
+  selectShouldLaunchOnboarding,
+} from './onboarding.selectors';
+import { RootState, slice } from './onboarding.slice';
+import { getOnboardingStepContent } from './onboarding.utils';
+
+const mockedGetOnboardingStepContent = getOnboardingStepContent as jest.Mock;
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    onboardingOld: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('onboardingOld.selectors', () => {
+  afterEach(() => {
+    mockedGetOnboardingStepContent.mockReset();
+  });
+
+  describe('selectShouldLaunchOnboarding', () => {
+    it('returns the shouldLaunchOnboarding flag', () => {
+      expect(
+        selectShouldLaunchOnboarding(
+          buildState({ shouldLaunchOnboarding: false })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('selectOnboardingFlow', () => {
+    it('returns null by default', () => {
+      expect(selectOnboardingFlow(buildState())).toBeNull();
+    });
+
+    it('returns the selected flow', () => {
+      expect(
+        selectOnboardingFlow(
+          buildState({ onboardingFlow: OnboardingFlow.COMPANY })
+        )
+      ).toBe(OnboardingFlow.COMPANY);
+    });
+  });
+
+  describe('selectOnboardingData', () => {
+    it('returns the onboarding data', () => {
+      const data = { 1: { [OnboardingFlow.COMPANY]: { foo: 'bar' } as any } };
+
+      expect(selectOnboardingData(buildState({ data }))).toEqual(data);
+    });
+  });
+
+  describe('selectOnboardingCurrentStep', () => {
+    it('returns the current step', () => {
+      expect(selectOnboardingCurrentStep(buildState({ currentStep: 2 }))).toBe(
+        2
+      );
+    });
+  });
+
+  describe('selectIsOnboardingLoading', () => {
+    it('returns the isLoading flag', () => {
+      expect(selectIsOnboardingLoading(buildState({ isLoading: false }))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('selectOnboardingCurrentStepData', () => {
+    it('throws when the current step is not defined', () => {
+      expect(() =>
+        selectOnboardingCurrentStepData(
+          buildState({ currentStep: undefined as any })
+        )
+      ).toThrow();
+    });
+
+    it('returns null when there is no onboarding flow', () => {
+      expect(
+        selectOnboardingCurrentStepData(
+          buildState({ currentStep: 1, onboardingFlow: null })
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when there is no data for the current step and flow', () => {
+      expect(
+        selectOnboardingCurrentStepData(
+          buildState({
+            currentStep: 1,
+            onboardingFlow: OnboardingFlow.COMPANY,
+            data: {},
+          })
+        )
+      ).toBeNull();
+    });
+
+    it('returns the stored form data for the current step and flow', () => {
+      const formData = { foo: 'bar' } as any;
+
+      expect(
+        selectOnboardingCurrentStepData(
+          buildState({
+            currentStep: 1,
+            onboardingFlow: OnboardingFlow.COMPANY,
+            data: { 1: { [OnboardingFlow.COMPANY]: formData } },
+          })
+        )
+      ).toEqual(formData);
+    });
+  });
+
+  describe('selectOnboardingCurrentStepContent', () => {
+    it('throws when the current step is not defined', () => {
+      expect(() =>
+        selectOnboardingCurrentStepContent(
+          buildState({ currentStep: undefined as any })
+        )
+      ).toThrow();
+    });
+
+    it('returns null when there is no onboarding flow', () => {
+      expect(
+        selectOnboardingCurrentStepContent(
+          buildState({ currentStep: 1, onboardingFlow: null })
+        )
+      ).toBeNull();
+    });
+
+    it('returns the step content for the current step of the selected flow', () => {
+      const stepContent = { title: 'Step 1' } as any;
+      mockedGetOnboardingStepContent.mockReturnValue({ 1: stepContent });
+
+      expect(
+        selectOnboardingCurrentStepContent(
+          buildState({ currentStep: 1, onboardingFlow: OnboardingFlow.COMPANY })
+        )
+      ).toBe(stepContent);
+      expect(mockedGetOnboardingStepContent).toHaveBeenCalledWith(
+        OnboardingFlow.COMPANY
+      );
+    });
+
+    it('returns undefined when there is no content for the current step', () => {
+      mockedGetOnboardingStepContent.mockReturnValue({});
+
+      expect(
+        selectOnboardingCurrentStepContent(
+          buildState({ currentStep: 4, onboardingFlow: OnboardingFlow.COMPANY })
+        )
+      ).toBeUndefined();
+    });
+  });
+
+  describe('selectOnboardingDataFromOtherStep', () => {
+    it('returns null when there is no content for the current step', () => {
+      mockedGetOnboardingStepContent.mockReturnValue({});
+
+      expect(
+        selectOnboardingDataFromOtherStep(
+          buildState({ currentStep: 1, onboardingFlow: OnboardingFlow.COMPANY })
+        )
+      ).toBeNull();
+    });
+
+    it('returns null when the current step content does not depend on another step', () => {
+      mockedGetOnboardingStepContent.mockReturnValue({
+        1: { title: 'Step 1' },
+      });
+
+      expect(
+        selectOnboardingDataFromOtherStep(
+          buildState({ currentStep: 1, onboardingFlow: OnboardingFlow.COMPANY })
+        )
+      ).toBeNull();
+    });
+
+    it('returns the flattened values for only the keys listed in dependsOn', () => {
+      mockedGetOnboardingStepContent.mockReturnValue({
+        2: { title: 'Step 2', dependsOn: ['fieldA'] },
+      });
+
+      expect(
+        selectOnboardingDataFromOtherStep(
+          buildState({
+            currentStep: 2,
+            onboardingFlow: OnboardingFlow.COMPANY,
+            data: {
+              1: {
+                [OnboardingFlow.COMPANY]: {
+                  fieldA: 'valueA',
+                  fieldB: 'valueB',
+                } as any,
+              },
+            },
+          })
+        )
+      ).toEqual({ fieldA: 'valueA' });
+    });
+
+    it('returns undefined for a dependsOn key with no matching data across any step', () => {
+      mockedGetOnboardingStepContent.mockReturnValue({
+        2: { title: 'Step 2', dependsOn: ['missingField'] },
+      });
+
+      expect(
+        selectOnboardingDataFromOtherStep(
+          buildState({
+            currentStep: 2,
+            onboardingFlow: OnboardingFlow.COMPANY,
+            data: {},
+          })
+        )
+      ).toEqual({ missingField: undefined });
+    });
+  });
+});

--- a/src/use-cases/onboardingOld/onboarding.slice.spec.ts
+++ b/src/use-cases/onboardingOld/onboarding.slice.spec.ts
@@ -1,0 +1,221 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { OnboardingFlow } from '@/src/features/backoffice/onboardingLegacy/Onboarding.types';
+import { slice } from './onboarding.slice';
+
+const { actions, reducer } = slice;
+
+describe('onboardingOld slice', () => {
+  describe('sendStepDataOnboardingSucceeded', () => {
+    it('is a no-op on domain fields (only the request status transitions)', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        isLoading: true,
+        sendStepDataError: 'NOT_SAVE_DATA' as const,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.sendStepDataOnboardingSucceeded()
+      );
+
+      expect(state.isLoading).toBe(true);
+      expect(state.sendStepDataError).toBe('NOT_SAVE_DATA');
+    });
+  });
+
+  describe('sendStepDataOnboardingFailed', () => {
+    it('sets isLoading to false and stores the error', () => {
+      const initialState = { ...slice.getInitialState(), isLoading: true };
+
+      const state = reducer(
+        initialState,
+        actions.sendStepDataOnboardingFailed({ error: 'NOT_SAVE_DATA' })
+      );
+
+      expect(state.isLoading).toBe(false);
+      expect(state.sendStepDataError).toBe('NOT_SAVE_DATA');
+    });
+
+    it('resets the error to null when the payload has no error', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        sendStepDataError: 'NOT_SAVE_DATA' as const,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.sendStepDataOnboardingFailed(null)
+      );
+
+      expect(state.sendStepDataError).toBeNull();
+    });
+  });
+
+  describe('launchOnboarding', () => {
+    it('sets the onboarding flow', () => {
+      const state = reducer(
+        undefined,
+        actions.launchOnboarding(OnboardingFlow.COMPANY)
+      );
+
+      expect(state.onboardingFlow).toBe(OnboardingFlow.COMPANY);
+    });
+  });
+
+  describe('setOnboardingCurrentStepData', () => {
+    it('throws when the current step is not defined', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: undefined as any,
+        onboardingFlow: OnboardingFlow.COMPANY,
+      };
+
+      expect(() =>
+        reducer(
+          initialState,
+          actions.setOnboardingCurrentStepData({ foo: 'bar' } as any)
+        )
+      ).toThrow();
+    });
+
+    it('throws when the onboarding flow is not defined', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 1 as const,
+        onboardingFlow: null,
+      };
+
+      expect(() =>
+        reducer(
+          initialState,
+          actions.setOnboardingCurrentStepData({ foo: 'bar' } as any)
+        )
+      ).toThrow();
+    });
+
+    it('stores the payload under the current step and the onboarding flow', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 1 as const,
+        onboardingFlow: OnboardingFlow.COMPANY,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setOnboardingCurrentStepData({ foo: 'bar' } as any)
+      );
+
+      expect(state.data[1]?.[OnboardingFlow.COMPANY]).toEqual({ foo: 'bar' });
+    });
+
+    it('leaves data for other steps untouched', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 1 as const,
+        onboardingFlow: OnboardingFlow.COMPANY,
+        data: {
+          2: { [OnboardingFlow.COMPANY]: { untouched: true } as any },
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setOnboardingCurrentStepData({ foo: 'bar' } as any)
+      );
+
+      expect(state.data[2]?.[OnboardingFlow.COMPANY]).toEqual({
+        untouched: true,
+      });
+      expect(state.data[1]?.[OnboardingFlow.COMPANY]).toEqual({ foo: 'bar' });
+    });
+
+    it('fully replaces (does not field-merge) previous data for the same step and flow', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 1 as const,
+        onboardingFlow: OnboardingFlow.COMPANY,
+        data: {
+          1: {
+            [OnboardingFlow.COMPANY]: { foo: 'old', other: 'kept?' } as any,
+          },
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setOnboardingCurrentStepData({ foo: 'new' } as any)
+      );
+
+      expect(state.data[1]?.[OnboardingFlow.COMPANY]).toEqual({ foo: 'new' });
+    });
+  });
+
+  describe('setOnboardingStep', () => {
+    it('sets the current step and sets isLoading to true', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        isLoading: false,
+      };
+
+      const state = reducer(initialState, actions.setOnboardingStep(2));
+
+      expect(state.currentStep).toBe(2);
+      expect(state.isLoading).toBe(true);
+    });
+  });
+
+  describe('setOnboardingIsLoading', () => {
+    it('sets isLoading', () => {
+      const state = reducer(undefined, actions.setOnboardingIsLoading(false));
+
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('increaseOnboardingStep', () => {
+    it('increments the current step', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 1 as const,
+      };
+
+      const state = reducer(initialState, actions.increaseOnboardingStep());
+
+      expect(state.currentStep).toBe(2);
+    });
+  });
+
+  describe('decreaseOnboardingStep', () => {
+    it('decrements the current step', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 2 as const,
+      };
+
+      const state = reducer(initialState, actions.decreaseOnboardingStep());
+
+      expect(state.currentStep).toBe(1);
+    });
+  });
+
+  describe('endOnboarding', () => {
+    it('resets the onboarding progress but keeps it from re-launching', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 3 as const,
+        data: { 1: { [OnboardingFlow.COMPANY]: { foo: 'bar' } as any } },
+        onboardingFlow: OnboardingFlow.COMPANY,
+        isLoading: false,
+      };
+
+      const state = reducer(initialState, actions.endOnboarding());
+
+      expect(state.currentStep).toBe(0);
+      expect(state.data).toEqual({});
+      expect(state.shouldLaunchOnboarding).toBe(false);
+      expect(state.isLoading).toBe(true);
+      expect(state.onboardingFlow).toBeNull();
+    });
+  });
+});

--- a/src/use-cases/profile-completion/profile-completion.saga.spec.ts
+++ b/src/use-cases/profile-completion/profile-completion.saga.spec.ts
@@ -1,0 +1,127 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { currentUserActions } from '@/src/use-cases/current-user';
+import { slice } from './profile-completion.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+/**
+ * `refreshProfileCompletionSaga` waits ~300ms (a raw `setTimeout` promise,
+ * not a `call` effect) before re-fetching the completion rate, so behavioral
+ * tests exercising it must wait past that real delay before asserting.
+ */
+function waitForRefreshDelay() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 320);
+  });
+}
+
+describe('profile-completion saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchProfileCompletionRequested', () => {
+    it('fetches the completion rate and dispatches fetchProfileCompletionSucceeded', async () => {
+      const store = createTestStore();
+      mockedApi.getProfileCompletion.mockResolvedValue({ data: 55 } as any);
+
+      store.dispatch(actions.fetchProfileCompletionRequested());
+      await flushPromises();
+
+      expect(store.getState().profileCompletion.completionRate).toBe(55);
+      expect(
+        store.getState().profileCompletion.fetchProfileCompletion.status
+      ).toBe('SUCCEEDED');
+    });
+
+    it('falls back to a completion rate of 0 when the API returns no data', async () => {
+      const store = createTestStore();
+      mockedApi.getProfileCompletion.mockResolvedValue({
+        data: undefined,
+      } as any);
+
+      store.dispatch(actions.fetchProfileCompletionRequested());
+      await flushPromises();
+
+      expect(store.getState().profileCompletion.completionRate).toBe(0);
+    });
+
+    it('dispatches fetchProfileCompletionFailed and preserves the previous rate when the API call rejects', async () => {
+      const store = createTestStore({
+        profileCompletion: {
+          ...slice.getInitialState(),
+          completionRate: 40,
+        },
+      });
+      mockedApi.getProfileCompletion.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchProfileCompletionRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().profileCompletion.fetchProfileCompletion.status
+      ).toBe('FAILED');
+      expect(store.getState().profileCompletion.completionRate).toBe(40);
+    });
+  });
+
+  describe('refreshProfileCompletionSaga (cross-domain triggers)', () => {
+    const scenarios: {
+      name: string;
+      trigger: () => { type: string; payload: unknown };
+    }[] = [
+      {
+        name: 'updateProfileSucceeded',
+        trigger: () =>
+          currentUserActions.updateProfileSucceeded({ userProfile: {} as any }),
+      },
+      {
+        name: 'updateUserProfilePictureSucceeded',
+        trigger: () => currentUserActions.updateUserProfilePictureSucceeded(),
+      },
+      {
+        name: 'uploadExternalCvSucceeded',
+        trigger: () => currentUserActions.uploadExternalCvSucceeded(),
+      },
+      {
+        name: 'deleteExternalCvSucceeded',
+        trigger: () => currentUserActions.deleteExternalCvSucceeded(),
+      },
+    ];
+
+    scenarios.forEach(({ name, trigger }) => {
+      it(`re-fetches the completion rate after ${name} (past the debounce delay)`, async () => {
+        const store = createTestStore();
+        mockedApi.getProfileCompletion.mockResolvedValue({ data: 90 } as any);
+
+        store.dispatch(trigger());
+        await waitForRefreshDelay();
+        await flushPromises();
+
+        expect(mockedApi.getProfileCompletion).toHaveBeenCalled();
+        expect(store.getState().profileCompletion.completionRate).toBe(90);
+      });
+    });
+
+    it('does not re-fetch before the debounce delay has elapsed', async () => {
+      const store = createTestStore();
+      mockedApi.getProfileCompletion.mockResolvedValue({ data: 90 } as any);
+
+      store.dispatch(
+        currentUserActions.updateProfileSucceeded({ userProfile: {} as any })
+      );
+      await flushPromises();
+
+      expect(mockedApi.getProfileCompletion).not.toHaveBeenCalled();
+      expect(store.getState().profileCompletion.completionRate).toBe(0);
+    });
+  });
+});

--- a/src/use-cases/profile-completion/profile-completion.selectors.spec.ts
+++ b/src/use-cases/profile-completion/profile-completion.selectors.spec.ts
@@ -1,0 +1,25 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { selectProfileCompletionRate } from './profile-completion.selectors';
+import { RootState, slice } from './profile-completion.slice';
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    profileCompletion: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('profile-completion.selectors', () => {
+  describe('selectProfileCompletionRate', () => {
+    it('returns the completion rate from state', () => {
+      expect(
+        selectProfileCompletionRate(buildState({ completionRate: 65 }))
+      ).toBe(65);
+    });
+
+    it('returns 0 by default', () => {
+      expect(selectProfileCompletionRate(buildState())).toBe(0);
+    });
+  });
+});

--- a/src/use-cases/profile-completion/profile-completion.slice.spec.ts
+++ b/src/use-cases/profile-completion/profile-completion.slice.spec.ts
@@ -1,0 +1,48 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { slice } from './profile-completion.slice';
+
+const { actions, reducer } = slice;
+
+describe('profile-completion slice', () => {
+  describe('fetchProfileCompletionSucceeded', () => {
+    it('sets completionRate to the payload value', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchProfileCompletionSucceeded(75)
+      );
+
+      expect(state.completionRate).toBe(75);
+    });
+
+    it('overwrites a previously stored completionRate', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        completionRate: 30,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfileCompletionSucceeded(80)
+      );
+
+      expect(state.completionRate).toBe(80);
+    });
+  });
+
+  describe('fetchProfileCompletionFailed', () => {
+    it('leaves completionRate unchanged (no-op on failure)', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        completionRate: 42,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfileCompletionFailed(null)
+      );
+
+      expect(state.completionRate).toBe(42);
+    });
+  });
+});

--- a/src/use-cases/profiles/profiles.saga.spec.ts
+++ b/src/use-cases/profiles/profiles.saga.spec.ts
@@ -1,0 +1,212 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { ProfilesFilters } from '@/src/api/types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice } from './profiles.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildFilters = (overrides: Partial<ProfilesFilters> = {}) =>
+  ({
+    role: 'coach',
+    nudgeIds: [],
+    departments: [],
+    businessSectorIds: [],
+    contactTypes: [],
+    ...overrides,
+  }) as ProfilesFilters;
+
+describe('profiles saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchProfilesRequested', () => {
+    it('stores the returned profiles on success', async () => {
+      const store = createTestStore();
+      const profiles = [{ id: 'profile-1' }] as any;
+      mockedApi.getAllUsersProfiles.mockResolvedValue({
+        data: profiles,
+      } as any);
+
+      store.dispatch(actions.fetchProfilesRequested(buildFilters()));
+      await flushPromises();
+
+      expect(store.getState().profiles.profiles).toEqual(profiles);
+      expect(store.getState().profiles.fetchProfiles.status).toBe('SUCCEEDED');
+    });
+
+    it('dispatches fetchProfilesFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getAllUsersProfiles.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchProfilesRequested(buildFilters()));
+      await flushPromises();
+
+      expect(store.getState().profiles.fetchProfiles.status).toBe('FAILED');
+    });
+  });
+
+  describe('fetchProfilesWithFilters', () => {
+    it('resets pagination and fetches profiles with the given filters', async () => {
+      const store = createTestStore({
+        profiles: {
+          ...slice.getInitialState(),
+          profilesOffset: 50,
+          profilesHasFetchedAll: true,
+        },
+      });
+      const profiles = [{ id: 'profile-1' }] as any;
+      mockedApi.getAllUsersProfiles.mockResolvedValue({
+        data: profiles,
+      } as any);
+
+      store.dispatch(
+        actions.fetchProfilesWithFilters(buildFilters({ search: 'jean' }))
+      );
+      await flushPromises();
+
+      expect(store.getState().profiles.profilesOffset).toBe(0);
+      expect(store.getState().profiles.profiles).toEqual(profiles);
+      expect(mockedApi.getAllUsersProfiles).toHaveBeenCalledWith(
+        expect.objectContaining({ search: 'jean', offset: 0 })
+      );
+    });
+  });
+
+  describe('fetchProfilesNextPage', () => {
+    it('fetches the next page when not all profiles were fetched and no fetch is in flight', async () => {
+      const store = createTestStore({
+        profiles: {
+          ...slice.getInitialState(),
+          profilesHasFetchedAll: false,
+        },
+      });
+      mockedApi.getAllUsersProfiles.mockResolvedValue({ data: [] } as any);
+
+      store.dispatch(actions.fetchProfilesNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllUsersProfiles).toHaveBeenCalled();
+    });
+
+    it('does nothing when all profiles have already been fetched', async () => {
+      const store = createTestStore({
+        profiles: {
+          ...slice.getInitialState(),
+          profilesHasFetchedAll: true,
+        },
+      });
+
+      store.dispatch(actions.fetchProfilesNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllUsersProfiles).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when a fetch is already in flight', async () => {
+      const store = createTestStore({
+        profiles: {
+          ...slice.getInitialState(),
+          profilesHasFetchedAll: false,
+          fetchProfiles: { status: 'REQUESTED' as any },
+        },
+      });
+
+      store.dispatch(actions.fetchProfilesNextPage(buildFilters()));
+      await flushPromises();
+
+      expect(mockedApi.getAllUsersProfiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchDashboardProfilesRecommendationsRequested', () => {
+    it('stores the recommendations on success when embedding is not pending', async () => {
+      const store = createTestStore();
+      const recommendations = [
+        { id: 'rec-1', publicProfile: { id: 'profile-1' }, reason: 'needs' },
+      ] as any;
+      mockedApi.getProfilesRecommendations.mockResolvedValue({
+        data: { embeddingPending: false, recommendations, nextCursor: null },
+      } as any);
+
+      store.dispatch(actions.fetchDashboardProfilesRecommendationsRequested());
+      await flushPromises();
+
+      expect(store.getState().profiles.profilesRecommendations).toEqual(
+        recommendations
+      );
+      expect(store.getState().profiles.isEmbeddingPending).toBe(false);
+      expect(
+        store.getState().profiles.fetchDashboardProfilesRecommendations.status
+      ).toBe('SUCCEEDED');
+    });
+
+    it('forces an empty recommendations list when embedding is pending, ignoring any returned recommendations', async () => {
+      const store = createTestStore();
+      mockedApi.getProfilesRecommendations.mockResolvedValue({
+        data: {
+          embeddingPending: true,
+          recommendations: [{ id: 'rec-1' }],
+          nextCursor: 5,
+        },
+      } as any);
+
+      store.dispatch(actions.fetchDashboardProfilesRecommendationsRequested());
+      await flushPromises();
+
+      expect(store.getState().profiles.profilesRecommendations).toEqual([]);
+      expect(store.getState().profiles.isEmbeddingPending).toBe(true);
+    });
+
+    it('dispatches fetchDashboardProfilesRecommendationsFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getProfilesRecommendations.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchDashboardProfilesRecommendationsRequested());
+      await flushPromises();
+
+      expect(
+        store.getState().profiles.fetchDashboardProfilesRecommendations.status
+      ).toBe('FAILED');
+    });
+  });
+
+  describe('fetchSelectedProfileRequested', () => {
+    it('stores the selected profile on success', async () => {
+      const store = createTestStore();
+      const profile = { id: 'profile-1', firstName: 'Jean' } as any;
+      mockedApi.getPublicUserProfile.mockResolvedValue({
+        data: profile,
+      } as any);
+
+      store.dispatch(
+        actions.fetchSelectedProfileRequested({ userId: 'profile-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().profiles.selectedProfile).toEqual(profile);
+      expect(mockedApi.getPublicUserProfile).toHaveBeenCalledWith('profile-1');
+    });
+
+    it('dispatches fetchSelectedProfileFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getPublicUserProfile.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.fetchSelectedProfileRequested({ userId: 'profile-1' })
+      );
+      await flushPromises();
+
+      expect(store.getState().profiles.fetchSelectedProfile.status).toBe(
+        'FAILED'
+      );
+    });
+  });
+});

--- a/src/use-cases/profiles/profiles.selectors.spec.ts
+++ b/src/use-cases/profiles/profiles.selectors.spec.ts
@@ -1,0 +1,72 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { PublicProfile } from '@/src/api/types';
+import {
+  selectIsEmbeddingPending,
+  selectProfiles,
+  selectProfilesHasFetchedAll,
+  selectProfilesOffset,
+  selectProfilesRecommendations,
+  selectSelectedProfile,
+} from './profiles.selectors';
+import { RootState, slice } from './profiles.slice';
+
+const buildProfile = (overrides: Partial<PublicProfile> = {}) =>
+  ({
+    id: 'profile-1',
+    firstName: 'Jean',
+    lastName: 'Dupont',
+    ...overrides,
+  }) as PublicProfile;
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    profiles: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('profiles.selectors', () => {
+  it('selectProfiles returns the profiles list', () => {
+    const profiles = [buildProfile()];
+    expect(selectProfiles(buildState({ profiles }))).toEqual(profiles);
+  });
+
+  it('selectProfilesRecommendations returns the recommendations list', () => {
+    const profilesRecommendations = [
+      { id: 'rec-1', publicProfile: buildProfile(), reason: 'needs' },
+    ] as any;
+    expect(
+      selectProfilesRecommendations(buildState({ profilesRecommendations }))
+    ).toEqual(profilesRecommendations);
+  });
+
+  it('selectProfilesOffset returns the current pagination offset', () => {
+    expect(selectProfilesOffset(buildState({ profilesOffset: 25 }))).toBe(25);
+  });
+
+  it('selectProfilesHasFetchedAll returns the pagination flag', () => {
+    expect(
+      selectProfilesHasFetchedAll(buildState({ profilesHasFetchedAll: true }))
+    ).toBe(true);
+    expect(
+      selectProfilesHasFetchedAll(buildState({ profilesHasFetchedAll: false }))
+    ).toBe(false);
+  });
+
+  it('selectSelectedProfile returns the selected profile', () => {
+    const selectedProfile = buildProfile();
+    expect(selectSelectedProfile(buildState({ selectedProfile }))).toEqual(
+      selectedProfile
+    );
+  });
+
+  it('selectIsEmbeddingPending returns the embedding pending flag', () => {
+    expect(
+      selectIsEmbeddingPending(buildState({ isEmbeddingPending: true }))
+    ).toBe(true);
+    expect(
+      selectIsEmbeddingPending(buildState({ isEmbeddingPending: false }))
+    ).toBe(false);
+  });
+});

--- a/src/use-cases/profiles/profiles.slice.spec.ts
+++ b/src/use-cases/profiles/profiles.slice.spec.ts
@@ -1,0 +1,215 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { ProfilesFilters, PublicProfile } from '@/src/api/types';
+import { PROFILES_LIMIT, ReduxRequestEvents } from '@/src/constants';
+import { slice } from './profiles.slice';
+
+const { actions, reducer } = slice;
+
+const buildProfile = (overrides: Partial<PublicProfile> = {}) =>
+  ({
+    id: 'profile-1',
+    firstName: 'Jean',
+    lastName: 'Dupont',
+    ...overrides,
+  }) as PublicProfile;
+
+const buildFilters = (overrides: Partial<ProfilesFilters> = {}) =>
+  ({
+    role: 'coach',
+    nudgeIds: [],
+    departments: [],
+    businessSectorIds: [],
+    contactTypes: [],
+    ...overrides,
+  }) as ProfilesFilters;
+
+describe('profiles slice', () => {
+  describe('fetchProfilesSucceeded', () => {
+    it('replaces the profiles list when offset is 0', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        profilesOffset: 0,
+        profiles: [buildProfile({ id: 'stale' })],
+      };
+      const profiles = [buildProfile({ id: 'profile-1' })];
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfilesSucceeded(profiles)
+      );
+
+      expect(state.profiles).toEqual(profiles);
+    });
+
+    it('appends to the profiles list when offset is greater than 0', () => {
+      const existing = [buildProfile({ id: 'profile-1' })];
+      const initialState = {
+        ...slice.getInitialState(),
+        profilesOffset: PROFILES_LIMIT,
+        profiles: existing,
+      };
+      const nextPage = [buildProfile({ id: 'profile-2' })];
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfilesSucceeded(nextPage)
+      );
+
+      expect(state.profiles).toEqual([...existing, ...nextPage]);
+    });
+
+    it('marks profilesHasFetchedAll true when the page is smaller than the limit', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchProfilesSucceeded([buildProfile()])
+      );
+
+      expect(state.profilesHasFetchedAll).toBe(true);
+    });
+
+    it('marks profilesHasFetchedAll false when the page is full', () => {
+      const fullPage = Array.from({ length: PROFILES_LIMIT }, (_, i) =>
+        buildProfile({ id: `profile-${i}` })
+      );
+
+      const state = reducer(
+        undefined,
+        actions.fetchProfilesSucceeded(fullPage)
+      );
+
+      expect(state.profilesHasFetchedAll).toBe(false);
+    });
+  });
+
+  describe('fetchDashboardProfilesRecommendationsSucceeded', () => {
+    it('stores the recommendations and the embedding pending flag', () => {
+      const recommendations = [
+        { id: 'rec-1', publicProfile: buildProfile(), reason: 'needs' },
+      ] as any;
+
+      const state = reducer(
+        undefined,
+        actions.fetchDashboardProfilesRecommendationsSucceeded({
+          recommendations,
+          embeddingPending: true,
+          nextCursor: null,
+        })
+      );
+
+      expect(state.profilesRecommendations).toEqual(recommendations);
+      expect(state.isEmbeddingPending).toBe(true);
+    });
+  });
+
+  describe('fetchDashboardProfilesRecommendationsReset', () => {
+    it('clears the recommendations list and the embedding pending flag', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        profilesRecommendations: [{ id: 'rec-1' }] as any,
+        isEmbeddingPending: true,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchDashboardProfilesRecommendationsReset()
+      );
+
+      expect(state.profilesRecommendations).toEqual([]);
+      expect(state.isEmbeddingPending).toBe(false);
+    });
+  });
+
+  it('fetchSelectedProfileSucceeded sets selectedProfile', () => {
+    const profile = buildProfile();
+
+    const state = reducer(
+      undefined,
+      actions.fetchSelectedProfileSucceeded(profile)
+    );
+
+    expect(state.selectedProfile).toEqual(profile);
+  });
+
+  it('embeddingPendingChanged sets isEmbeddingPending', () => {
+    const state = reducer(undefined, actions.embeddingPendingChanged(true));
+
+    expect(state.isEmbeddingPending).toBe(true);
+  });
+
+  it('resetProfilesOffset resets pagination state', () => {
+    const initialState = {
+      ...slice.getInitialState(),
+      profilesOffset: PROFILES_LIMIT * 2,
+      profilesHasFetchedAll: true,
+      profiles: [buildProfile()],
+    };
+
+    const state = reducer(initialState, actions.resetProfilesOffset());
+
+    expect(state.profilesOffset).toBe(0);
+    expect(state.profilesHasFetchedAll).toBe(false);
+    expect(state.profiles).toEqual([]);
+  });
+
+  it('fetchProfilesWithFilters does not mutate state', () => {
+    const initialState = slice.getInitialState();
+
+    const state = reducer(
+      initialState,
+      actions.fetchProfilesWithFilters(buildFilters())
+    );
+
+    expect(state).toEqual(initialState);
+  });
+
+  describe('fetchProfilesNextPage', () => {
+    it('increments the offset when not all profiles are fetched and the previous fetch succeeded', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        profilesOffset: 0,
+        profilesHasFetchedAll: false,
+        fetchProfiles: { status: ReduxRequestEvents.SUCCEEDED },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfilesNextPage(buildFilters())
+      );
+
+      expect(state.profilesOffset).toBe(PROFILES_LIMIT);
+    });
+
+    it('does not increment the offset when all profiles are already fetched', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        profilesOffset: 0,
+        profilesHasFetchedAll: true,
+        fetchProfiles: { status: ReduxRequestEvents.SUCCEEDED },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfilesNextPage(buildFilters())
+      );
+
+      expect(state.profilesOffset).toBe(0);
+    });
+
+    it('does not increment the offset when a fetch is still in progress', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        profilesOffset: 0,
+        profilesHasFetchedAll: false,
+        fetchProfiles: { status: ReduxRequestEvents.REQUESTED },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.fetchProfilesNextPage(buildFilters())
+      );
+
+      expect(state.profilesOffset).toBe(0);
+    });
+  });
+});

--- a/src/use-cases/recruitement-alerts/recruitement-alerts.saga.spec.ts
+++ b/src/use-cases/recruitement-alerts/recruitement-alerts.saga.spec.ts
@@ -1,0 +1,300 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { RecruitementAlert, RecruitementAlertDto } from '@/src/api/types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice } from './recruitement-alerts.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+const buildRecruitementAlert = (
+  overrides: Partial<RecruitementAlert> = {}
+): RecruitementAlert =>
+  ({
+    id: 'alert-1',
+    name: 'Alert 1',
+    jobName: 'Developer',
+    department: null,
+    workingExperienceYears: null,
+    contractType: null,
+    companyId: 'company-1',
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+    ...overrides,
+  }) as RecruitementAlert;
+
+const buildRecruitementAlertDto = (
+  overrides: Partial<RecruitementAlertDto> = {}
+): RecruitementAlertDto =>
+  ({
+    companyId: 'company-1',
+    name: 'Alert 1',
+    jobName: 'Developer',
+    department: null,
+    workingExperienceYears: null,
+    contractType: null,
+    ...overrides,
+  }) as RecruitementAlertDto;
+
+describe('recruitement-alerts saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('fetchRecruitementAlertsAction', () => {
+    it('stores the returned alerts on success', async () => {
+      const store = createTestStore();
+      const alerts = [buildRecruitementAlert()];
+      mockedApi.getRecruitementAlerts.mockResolvedValue({
+        data: alerts,
+      } as any);
+
+      store.dispatch(actions.fetchRecruitementAlertsAction());
+      await flushPromises();
+
+      expect(store.getState().recruitementAlerts.recruitementAlerts).toEqual(
+        alerts
+      );
+      expect(
+        store.getState().recruitementAlerts.fetchRecruitementAlerts.status
+      ).toBe('SUCCEEDED');
+    });
+
+    it('dispatches fetchRecruitementAlertsFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getRecruitementAlerts.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.fetchRecruitementAlertsAction());
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.fetchRecruitementAlerts.status
+      ).toBe('FAILED');
+    });
+  });
+
+  describe('createRecruitementAlertAction', () => {
+    it('notifies and re-fetches the alerts list on success', async () => {
+      const store = createTestStore();
+      const createdAlert = buildRecruitementAlert();
+      mockedApi.createRecruitementAlert.mockResolvedValue({
+        data: createdAlert,
+      } as any);
+      const refreshedAlerts = [createdAlert];
+      mockedApi.getRecruitementAlerts.mockResolvedValue({
+        data: refreshedAlerts,
+      } as any);
+
+      store.dispatch(
+        actions.createRecruitementAlertAction(buildRecruitementAlertDto())
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.createRecruitementAlert.status
+      ).toBe('SUCCEEDED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().notifications.notifications[0].type).toBe(
+        'success'
+      );
+      expect(mockedApi.getRecruitementAlerts).toHaveBeenCalled();
+      expect(store.getState().recruitementAlerts.recruitementAlerts).toEqual(
+        refreshedAlerts
+      );
+    });
+
+    it('notifies of the failure when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.createRecruitementAlert.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.createRecruitementAlertAction(buildRecruitementAlertDto())
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.createRecruitementAlert.status
+      ).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().notifications.notifications[0].type).toBe(
+        'danger'
+      );
+      expect(mockedApi.getRecruitementAlerts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteRecruitementAlertAction', () => {
+    it('removes the matching entry, notifies and re-fetches the alerts list on success', async () => {
+      const store = createTestStore({
+        recruitementAlerts: {
+          ...slice.getInitialState(),
+          recruitementAlerts: [buildRecruitementAlert({ id: 'alert-1' })],
+          recruitementAlertMatchings: {
+            'alert-1': { profiles: [], timestamp: 123 },
+          },
+        },
+      });
+      mockedApi.deleteRecruitementAlert.mockResolvedValue({} as any);
+      mockedApi.getRecruitementAlerts.mockResolvedValue({ data: [] } as any);
+
+      store.dispatch(actions.deleteRecruitementAlertAction('alert-1'));
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.deleteRecruitementAlert.status
+      ).toBe('SUCCEEDED');
+      expect(
+        store.getState().recruitementAlerts.recruitementAlertMatchings
+      ).toEqual({});
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().notifications.notifications[0].type).toBe(
+        'success'
+      );
+      expect(mockedApi.getRecruitementAlerts).toHaveBeenCalled();
+    });
+
+    it('notifies of the failure and does not re-fetch when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.deleteRecruitementAlert.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.deleteRecruitementAlertAction('alert-1'));
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.deleteRecruitementAlert.status
+      ).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().notifications.notifications[0].type).toBe(
+        'danger'
+      );
+      expect(mockedApi.getRecruitementAlerts).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateRecruitementAlertAction', () => {
+    it('notifies, re-fetches the alerts list and the matching on success', async () => {
+      const store = createTestStore();
+      const updatedAlert = buildRecruitementAlert({ id: 'alert-1' });
+      mockedApi.updateRecruitementAlert.mockResolvedValue({
+        data: updatedAlert,
+      } as any);
+      mockedApi.getRecruitementAlerts.mockResolvedValue({
+        data: [updatedAlert],
+      } as any);
+      const matchingProfiles = [{ id: 'profile-1' }] as any;
+      mockedApi.getRecruitementAlertMatching.mockResolvedValue({
+        data: matchingProfiles,
+      } as any);
+
+      store.dispatch(
+        actions.updateRecruitementAlertAction({
+          id: 'alert-1',
+          data: buildRecruitementAlertDto(),
+        })
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.updateRecruitementAlert.status
+      ).toBe('SUCCEEDED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().notifications.notifications[0].type).toBe(
+        'success'
+      );
+      expect(mockedApi.getRecruitementAlerts).toHaveBeenCalled();
+      expect(mockedApi.getRecruitementAlertMatching).toHaveBeenCalledWith(
+        'alert-1'
+      );
+      expect(
+        store.getState().recruitementAlerts.recruitementAlertMatchings[
+          'alert-1'
+        ].profiles
+      ).toEqual(matchingProfiles);
+    });
+
+    it('notifies of the failure when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.updateRecruitementAlert.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(
+        actions.updateRecruitementAlertAction({
+          id: 'alert-1',
+          data: buildRecruitementAlertDto(),
+        })
+      );
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.updateRecruitementAlert.status
+      ).toBe('FAILED');
+      expect(store.getState().notifications.notifications).toHaveLength(1);
+      expect(store.getState().notifications.notifications[0].type).toBe(
+        'danger'
+      );
+    });
+  });
+
+  describe('fetchRecruitementAlertMatchingAction', () => {
+    it('stores the matching profiles keyed by alertId on success', async () => {
+      const store = createTestStore();
+      const profiles = [{ id: 'profile-1' }] as any;
+      mockedApi.getRecruitementAlertMatching.mockResolvedValue({
+        data: profiles,
+      } as any);
+
+      store.dispatch(actions.fetchRecruitementAlertMatchingAction('alert-1'));
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.fetchRecruitementAlertMatching
+          .status
+      ).toBe('SUCCEEDED');
+      expect(
+        store.getState().recruitementAlerts.recruitementAlertMatchings[
+          'alert-1'
+        ].profiles
+      ).toEqual(profiles);
+    });
+
+    it('defaults the stored profiles to an empty array when the API returns a non-array payload', async () => {
+      const store = createTestStore();
+      mockedApi.getRecruitementAlertMatching.mockResolvedValue({
+        data: { not: 'an array' },
+      } as any);
+
+      store.dispatch(actions.fetchRecruitementAlertMatchingAction('alert-1'));
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.recruitementAlertMatchings[
+          'alert-1'
+        ].profiles
+      ).toEqual([]);
+    });
+
+    it('dispatches fetchRecruitementAlertMatchingFailed when the API call rejects', async () => {
+      const store = createTestStore();
+      mockedApi.getRecruitementAlertMatching.mockRejectedValue(
+        new Error('boom')
+      );
+
+      store.dispatch(actions.fetchRecruitementAlertMatchingAction('alert-1'));
+      await flushPromises();
+
+      expect(
+        store.getState().recruitementAlerts.fetchRecruitementAlertMatching
+          .status
+      ).toBe('FAILED');
+      expect(
+        store.getState().recruitementAlerts.recruitementAlertMatchings[
+          'alert-1'
+        ]
+      ).toBeUndefined();
+    });
+  });
+});

--- a/src/use-cases/recruitement-alerts/recruitement-alerts.selectors.spec.ts
+++ b/src/use-cases/recruitement-alerts/recruitement-alerts.selectors.spec.ts
@@ -1,0 +1,105 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { RecruitementAlert } from '@/src/api/types';
+import {
+  selectFetchRecruitementAlertMatchingLoading,
+  selectFetchRecruitementAlertsLoading,
+  selectRecruitementAlertMatchingById,
+  selectRecruitementAlerts,
+} from './recruitement-alerts.selectors';
+import { RootState, slice } from './recruitement-alerts.slice';
+
+const buildRecruitementAlert = (
+  overrides: Partial<RecruitementAlert> = {}
+): RecruitementAlert =>
+  ({
+    id: 'alert-1',
+    name: 'Alert 1',
+    jobName: 'Developer',
+    department: null,
+    workingExperienceYears: null,
+    contractType: null,
+    companyId: 'company-1',
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+    ...overrides,
+  }) as RecruitementAlert;
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    recruitementAlerts: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('recruitement-alerts.selectors', () => {
+  describe('selectRecruitementAlerts', () => {
+    it('returns the recruitement alerts list', () => {
+      const recruitementAlerts = [buildRecruitementAlert()];
+
+      expect(
+        selectRecruitementAlerts(buildState({ recruitementAlerts }))
+      ).toEqual(recruitementAlerts);
+    });
+  });
+
+  describe('selectRecruitementAlertMatchingById', () => {
+    it('returns the matching entry for the given alertId', () => {
+      const matching = {
+        profiles: [{ id: 'profile-1' }] as any,
+        timestamp: 123,
+      };
+      const state = buildState({
+        recruitementAlertMatchings: { 'alert-1': matching },
+      });
+
+      expect(selectRecruitementAlertMatchingById('alert-1')(state)).toEqual(
+        matching
+      );
+    });
+
+    it('returns an empty default when there is no matching entry for the alertId', () => {
+      const state = buildState({ recruitementAlertMatchings: {} });
+
+      expect(
+        selectRecruitementAlertMatchingById('unknown-alert')(state)
+      ).toEqual({ profiles: [], timestamp: 0 });
+    });
+  });
+
+  describe('selectFetchRecruitementAlertsLoading', () => {
+    it('returns true while the alerts fetch is requested', () => {
+      const state = buildState({
+        fetchRecruitementAlerts: { status: 'REQUESTED' as any },
+      });
+
+      expect(selectFetchRecruitementAlertsLoading(state)).toBe(true);
+    });
+
+    it('returns false when the alerts fetch is not requested', () => {
+      const state = buildState({
+        fetchRecruitementAlerts: { status: 'SUCCEEDED' as any },
+      });
+
+      expect(selectFetchRecruitementAlertsLoading(state)).toBe(false);
+    });
+  });
+
+  describe('selectFetchRecruitementAlertMatchingLoading', () => {
+    it('returns true while the matching fetch is requested', () => {
+      const state = buildState({
+        fetchRecruitementAlertMatching: { status: 'REQUESTED' as any },
+      });
+
+      expect(selectFetchRecruitementAlertMatchingLoading(state)).toBe(true);
+    });
+
+    it('returns false when the matching fetch is not requested', () => {
+      const state = buildState({
+        fetchRecruitementAlertMatching: { status: 'IDLE' as any },
+      });
+
+      expect(selectFetchRecruitementAlertMatchingLoading(state)).toBe(false);
+    });
+  });
+});

--- a/src/use-cases/recruitement-alerts/recruitement-alerts.slice.spec.ts
+++ b/src/use-cases/recruitement-alerts/recruitement-alerts.slice.spec.ts
@@ -1,0 +1,228 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { RecruitementAlert } from '@/src/api/types';
+import { slice } from './recruitement-alerts.slice';
+
+const { actions, reducer } = slice;
+
+const buildRecruitementAlert = (
+  overrides: Partial<RecruitementAlert> = {}
+): RecruitementAlert =>
+  ({
+    id: 'alert-1',
+    name: 'Alert 1',
+    jobName: 'Developer',
+    department: null,
+    workingExperienceYears: null,
+    contractType: null,
+    companyId: 'company-1',
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+    ...overrides,
+  }) as RecruitementAlert;
+
+describe('recruitement-alerts slice', () => {
+  describe('fetchRecruitementAlertsSucceeded', () => {
+    it('sets the recruitement alerts list', () => {
+      const alerts = [buildRecruitementAlert()];
+
+      const state = reducer(
+        undefined,
+        actions.fetchRecruitementAlertsSucceeded(alerts)
+      );
+
+      expect(state.recruitementAlerts).toEqual(alerts);
+    });
+  });
+
+  describe('deleteRecruitementAlertSucceeded', () => {
+    it('removes the deleted alert from the list', () => {
+      const remaining = buildRecruitementAlert({ id: 'alert-2' });
+      const initialState = {
+        ...slice.getInitialState(),
+        recruitementAlerts: [
+          buildRecruitementAlert({ id: 'alert-1' }),
+          remaining,
+        ],
+      };
+
+      const state = reducer(
+        initialState,
+        actions.deleteRecruitementAlertSucceeded('alert-1')
+      );
+
+      expect(state.recruitementAlerts).toEqual([remaining]);
+    });
+
+    it('removes the associated matching entry when one exists', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        recruitementAlerts: [buildRecruitementAlert({ id: 'alert-1' })],
+        recruitementAlertMatchings: {
+          'alert-1': { profiles: [], timestamp: 123 },
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.deleteRecruitementAlertSucceeded('alert-1')
+      );
+
+      expect(state.recruitementAlertMatchings).toEqual({});
+    });
+
+    it('does not throw when there is no matching entry for the deleted alert', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        recruitementAlerts: [buildRecruitementAlert({ id: 'alert-1' })],
+        recruitementAlertMatchings: {},
+      };
+
+      expect(() =>
+        reducer(
+          initialState,
+          actions.deleteRecruitementAlertSucceeded('alert-1')
+        )
+      ).not.toThrow();
+    });
+  });
+
+  describe('updateRecruitementAlertSucceeded', () => {
+    it('replaces the matching alert in the list', () => {
+      const untouched = buildRecruitementAlert({
+        id: 'alert-2',
+        name: 'Other',
+      });
+      const updatedAlert = buildRecruitementAlert({
+        id: 'alert-1',
+        name: 'Updated name',
+      });
+      const initialState = {
+        ...slice.getInitialState(),
+        recruitementAlerts: [
+          buildRecruitementAlert({ id: 'alert-1', name: 'Old name' }),
+          untouched,
+        ],
+      };
+
+      const state = reducer(
+        initialState,
+        actions.updateRecruitementAlertSucceeded(updatedAlert)
+      );
+
+      expect(state.recruitementAlerts).toEqual([updatedAlert, untouched]);
+    });
+
+    it('leaves the list unchanged when no alert matches the payload id', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        recruitementAlerts: [buildRecruitementAlert({ id: 'alert-1' })],
+      };
+
+      const state = reducer(
+        initialState,
+        actions.updateRecruitementAlertSucceeded(
+          buildRecruitementAlert({ id: 'unknown-alert' })
+        )
+      );
+
+      expect(state.recruitementAlerts).toEqual(initialState.recruitementAlerts);
+    });
+  });
+
+  describe('fetchRecruitementAlertMatchingSucceeded', () => {
+    it('stores the matching profiles keyed by alertId from action.meta.arg', () => {
+      const profiles = [{ id: 'profile-1' }] as any;
+      const action = {
+        type: actions.fetchRecruitementAlertMatchingSucceeded.type,
+        payload: profiles,
+        meta: { arg: 'alert-1' },
+      };
+
+      const state = reducer(undefined, action);
+
+      expect(state.recruitementAlertMatchings['alert-1'].profiles).toEqual(
+        profiles
+      );
+      expect(typeof state.recruitementAlertMatchings['alert-1'].timestamp).toBe(
+        'number'
+      );
+    });
+
+    it('defaults profiles to an empty array when the payload is not an array', () => {
+      const action = {
+        type: actions.fetchRecruitementAlertMatchingSucceeded.type,
+        payload: { not: 'an array' },
+        meta: { arg: 'alert-1' },
+      };
+
+      const state = reducer(undefined, action);
+
+      expect(state.recruitementAlertMatchings['alert-1'].profiles).toEqual([]);
+    });
+
+    it('is a no-op on recruitementAlertMatchings when there is no meta.arg', () => {
+      const state = reducer(
+        undefined,
+        actions.fetchRecruitementAlertMatchingSucceeded([] as any)
+      );
+
+      expect(state.recruitementAlertMatchings).toEqual({});
+    });
+  });
+
+  const plainTriggerActions: [
+    string,
+    () => { type: string; payload: unknown },
+  ][] = [
+    [
+      'fetchRecruitementAlertsAction',
+      () => actions.fetchRecruitementAlertsAction(),
+    ],
+    [
+      'createRecruitementAlertAction',
+      () =>
+        actions.createRecruitementAlertAction({
+          companyId: 'company-1',
+          name: 'Alert',
+          jobName: 'Developer',
+          department: null,
+          workingExperienceYears: null,
+          contractType: null,
+        }),
+    ],
+    [
+      'deleteRecruitementAlertAction',
+      () => actions.deleteRecruitementAlertAction('alert-1'),
+    ],
+    [
+      'updateRecruitementAlertAction',
+      () =>
+        actions.updateRecruitementAlertAction({
+          id: 'alert-1',
+          data: {
+            companyId: 'company-1',
+            name: 'Alert',
+            jobName: 'Developer',
+            department: null,
+            workingExperienceYears: null,
+            contractType: null,
+          },
+        }),
+    ],
+    [
+      'fetchRecruitementAlertMatchingAction',
+      () => actions.fetchRecruitementAlertMatchingAction('alert-1'),
+    ],
+  ];
+
+  plainTriggerActions.forEach(([name, buildAction]) => {
+    it(`${name} does not mutate the state (consumed by the saga only)`, () => {
+      const initialState = slice.getInitialState();
+
+      const state = reducer(initialState, buildAction());
+
+      expect(state).toEqual(initialState);
+    });
+  });
+});

--- a/src/use-cases/refering/refering.saga.spec.ts
+++ b/src/use-cases/refering/refering.saga.spec.ts
@@ -1,0 +1,219 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { CandidateYesNo } from '@/src/constants';
+import { Genders } from '@/src/constants/genders';
+import { ReferingStepData } from '@/src/features/backoffice/referer/Refering/Refering.types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice } from './refering.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+function buildAxiosError(status: number) {
+  return {
+    isAxiosError: true,
+    response: { status },
+  };
+}
+
+// A complete, valid data set spanning all 4 refering steps, matching the
+// fields each step's form schema declares (see
+// src/features/backoffice/referer/forms/*).
+function buildFullReferingData(
+  overrides: Partial<{
+    'step-1': Record<string, unknown>;
+    'step-2': Record<string, unknown>;
+    'step-3': Record<string, unknown>;
+    'step-4': Record<string, unknown>;
+  }> = {}
+): ReferingStepData {
+  return {
+    'step-1': {
+      firstName: 'Jean',
+      lastName: 'Dupont',
+      gender: Genders.MALE,
+      phone: '+33612345678',
+      email: 'jean@example.com',
+      confirmReferingRules: true,
+      ...overrides['step-1'],
+    },
+    'step-2': {
+      nudgeIds: ['nudge-1'],
+      ...overrides['step-2'],
+    },
+    'step-3': {
+      birthDate: '2000-01-01',
+      department: { value: 'Paris', label: 'Paris' },
+      workingRight: CandidateYesNo.YES,
+      materialInsecurity: CandidateYesNo.NO,
+      networkInsecurity: CandidateYesNo.NO,
+      ...overrides['step-3'],
+    },
+    'step-4': {
+      businessSectorId0: { value: 'sector-1', label: 'Sector One' },
+      occupation0: 'Chef de projet',
+      businessSectorId1: { value: 'sector-2', label: 'Sector Two' },
+      occupation1: 'Développeur',
+      ...overrides['step-4'],
+    },
+  } as unknown as ReferingStepData;
+}
+
+describe('refering saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('referCandidateRequested', () => {
+    it('posts the flattened, computed candidate payload on success', async () => {
+      const store = createTestStore({
+        refering: { ...slice.getInitialState(), data: buildFullReferingData() },
+      });
+      mockedApi.postUserRefering.mockResolvedValue({} as any);
+
+      store.dispatch(actions.referCandidateRequested());
+      await flushPromises();
+
+      expect(mockedApi.postUserRefering).toHaveBeenCalledWith({
+        firstName: 'Jean',
+        lastName: 'Dupont',
+        gender: Genders.MALE,
+        phone: '+33612345678',
+        email: 'jean@example.com',
+        birthDate: '2000-01-01',
+        department: 'Paris',
+        workingRight: CandidateYesNo.YES,
+        materialInsecurity: CandidateYesNo.NO,
+        networkInsecurity: CandidateYesNo.NO,
+        sectorOccupations: [
+          {
+            businessSectorId: 'sector-1',
+            businessSector: { id: 'sector-1', name: 'Sector One' },
+            occupation: { name: 'Chef de projet' },
+            order: 0,
+          },
+          {
+            businessSectorId: 'sector-2',
+            businessSector: { id: 'sector-2', name: 'Sector Two' },
+            occupation: { name: 'Développeur' },
+            order: 1,
+          },
+        ],
+        nudges: [{ id: 'nudge-1' }],
+      });
+      expect(store.getState().refering.referCandate.status).toBe('SUCCEEDED');
+    });
+
+    it('omits nudges when no nudge was selected', async () => {
+      const store = createTestStore({
+        refering: {
+          ...slice.getInitialState(),
+          data: buildFullReferingData({ 'step-2': { nudgeIds: [] } }),
+        },
+      });
+      mockedApi.postUserRefering.mockResolvedValue({} as any);
+
+      store.dispatch(actions.referCandidateRequested());
+      await flushPromises();
+
+      expect(mockedApi.postUserRefering).toHaveBeenCalledWith(
+        expect.objectContaining({ nudges: undefined })
+      );
+    });
+
+    it('stores a DUPLICATE_EMAIL error on a 409 conflict', async () => {
+      const store = createTestStore({
+        refering: { ...slice.getInitialState(), data: buildFullReferingData() },
+      });
+      mockedApi.postUserRefering.mockRejectedValue(buildAxiosError(409));
+
+      store.dispatch(actions.referCandidateRequested());
+      await flushPromises();
+
+      expect(store.getState().refering.referCandate.status).toBe('FAILED');
+      expect(store.getState().refering.referCandidateError).toBe(
+        'DUPLICATE_EMAIL'
+      );
+    });
+
+    it('stores no error on a generic failure', async () => {
+      const store = createTestStore({
+        refering: { ...slice.getInitialState(), data: buildFullReferingData() },
+      });
+      mockedApi.postUserRefering.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.referCandidateRequested());
+      await flushPromises();
+
+      expect(store.getState().refering.referCandate.status).toBe('FAILED');
+      expect(store.getState().refering.referCandidateError).toBeNull();
+    });
+  });
+
+  describe('setReferingCurrentStepData', () => {
+    it('submits the candidate when the current step is the last one', async () => {
+      const store = createTestStore({
+        refering: {
+          ...slice.getInitialState(),
+          currentStep: 'step-4',
+          data: buildFullReferingData(),
+        },
+      });
+      mockedApi.postUserRefering.mockResolvedValue({} as any);
+
+      store.dispatch(
+        actions.setReferingCurrentStepData({
+          businessSectorId0: { value: 'sector-1', label: 'Sector One' },
+          occupation0: 'Chef de projet',
+          businessSectorId1: { value: 'sector-2', label: 'Sector Two' },
+          occupation1: 'Développeur',
+        })
+      );
+      await flushPromises();
+
+      expect(store.getState().refering.isLoading).toBe(true);
+      expect(mockedApi.postUserRefering).toHaveBeenCalled();
+      expect(store.getState().refering.referCandate.status).toBe('SUCCEEDED');
+    });
+
+    it('does not submit the candidate on an intermediate step', async () => {
+      const store = createTestStore({
+        refering: {
+          ...slice.getInitialState(),
+          currentStep: 'step-2',
+          data: buildFullReferingData(),
+        },
+      });
+
+      store.dispatch(
+        actions.setReferingCurrentStepData({ nudgeIds: ['nudge-1'] })
+      );
+      await flushPromises();
+
+      expect(mockedApi.postUserRefering).not.toHaveBeenCalled();
+      expect(store.getState().refering.referCandate.status).toBe('IDLE');
+    });
+  });
+
+  describe('setReferingStep', () => {
+    it('stops loading after the step-change delay', async () => {
+      const store = createTestStore();
+
+      store.dispatch(actions.setReferingStep('step-2'));
+
+      expect(store.getState().refering.currentStep).toBe('step-2');
+      expect(store.getState().refering.isLoading).toBe(true);
+
+      // `setReferingStepSaga` waits a real 500ms (`asyncTimeout`) before
+      // dispatching `setReferingIsLoading(false)` — not backed by a mock or
+      // fake timer, so the test waits it out for real.
+      await new Promise((resolve) => setTimeout(resolve, 700));
+
+      expect(store.getState().refering.isLoading).toBe(false);
+    });
+  });
+});

--- a/src/use-cases/refering/refering.selectors.spec.ts
+++ b/src/use-cases/refering/refering.selectors.spec.ts
@@ -1,0 +1,316 @@
+// `ReferingStepContents` (the real, shipped step configuration) never
+// configures `dependsOn`/`skippedBy` on any step today (verified by
+// grepping the feature folder) — so the branches of
+// `selectReferingDataFromOtherStep`/`selectReferingShouldSkipStep` that
+// read them are unreachable through the real config. To exercise that
+// hand-written logic anyway, `step-2` is augmented here with a synthetic
+// `dependsOn`/`skippedBy` via `jest.mock`, purely at the test-file level —
+// production code and its real config are untouched. Every other step
+// (and every other property of step-2) is left as the real, unmocked
+// content, so all other assertions below still reflect real behavior.
+jest.mock('@/src/features/backoffice/referer/Refering/Refering.types', () => {
+  const actual = jest.requireActual(
+    '@/src/features/backoffice/referer/Refering/Refering.types'
+  ) as any;
+
+  return {
+    ...actual,
+    ReferingStepContents: {
+      ...actual.ReferingStepContents,
+      'step-2': {
+        ...actual.ReferingStepContents['step-2'],
+        dependsOn: ['gender', 'nudgeIds'],
+        // `selectReferingShouldSkipStep` only compares truthy values (see
+        // `if (valuesFromOtherStep[key])`), so `Genders.MALE` (`0`) can
+        // never match here — tests below use `FEMALE`/`OTHER` instead.
+        skippedBy: { gender: [1], nudgeIds: ['nudge-1'] },
+      },
+    },
+  };
+});
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { Genders } from '@/src/constants/genders';
+import { LastStepContent } from '@/src/features/backoffice/referer/Refering/Refering.types';
+import {
+  referCandidateSelectors,
+  selectIsEmptyReferingData,
+  selectIsFirstReferingStep,
+  selectIsLastReferingStep,
+  selectIsReferingLoading,
+  selectReferCandidateError,
+  selectReferingConfirmationStepContent,
+  selectReferingCurrentStep,
+  selectReferingCurrentStepContent,
+  selectReferingCurrentStepData,
+  selectReferingData,
+  selectReferingDataFromOtherStep,
+  selectReferingNextStep,
+  selectReferingShouldSkipStep,
+} from './refering.selectors';
+import { RootState, slice } from './refering.slice';
+
+// `data` is keyed by `ReferingStep` string (e.g. 'step-1') at runtime — the
+// type's numeric index signature only accepts that through a cast, matching
+// how the production reducer itself reads `state.data[currentStep]`.
+const buildState = (
+  overrides: Partial<Omit<ReturnType<typeof slice.getInitialState>, 'data'>> & {
+    data?: Record<string, unknown>;
+  } = {}
+): RootState =>
+  ({
+    refering: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+describe('refering.selectors', () => {
+  describe('referCandidateSelectors', () => {
+    it('reads the request status from refering.referCandate', () => {
+      const state = buildState({ referCandate: { status: 'SUCCEEDED' } });
+
+      expect(referCandidateSelectors.selectReferCandidateStatus(state)).toBe(
+        'SUCCEEDED'
+      );
+      expect(
+        referCandidateSelectors.selectIsReferCandidateSucceeded(state)
+      ).toBe(true);
+    });
+  });
+
+  describe('selectReferCandidateError', () => {
+    it('returns the stored error', () => {
+      expect(
+        selectReferCandidateError(
+          buildState({ referCandidateError: 'DUPLICATE_EMAIL' })
+        )
+      ).toBe('DUPLICATE_EMAIL');
+    });
+
+    it('returns null when there is no error', () => {
+      expect(selectReferCandidateError(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectIsEmptyReferingData', () => {
+    it('is true when no data has been collected', () => {
+      expect(selectIsEmptyReferingData(buildState())).toBe(true);
+    });
+
+    it('is false once some step data has been collected', () => {
+      expect(
+        selectIsEmptyReferingData(
+          buildState({ data: { 'step-1': { firstName: 'Jean' } } })
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('selectReferingData', () => {
+    it('returns the raw per-step data', () => {
+      const data = { 'step-1': { firstName: 'Jean' } };
+
+      expect(selectReferingData(buildState({ data }))).toBe(data);
+    });
+  });
+
+  describe('selectReferingCurrentStep', () => {
+    it('returns the current step', () => {
+      expect(
+        selectReferingCurrentStep(buildState({ currentStep: 'step-2' }))
+      ).toBe('step-2');
+    });
+
+    it('returns null when there is no current step', () => {
+      expect(selectReferingCurrentStep(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectReferingNextStep', () => {
+    it('increments the current step', () => {
+      expect(
+        selectReferingNextStep(buildState({ currentStep: 'step-1' }))
+      ).toBe('step-2');
+    });
+
+    it('throws when there is no current step', () => {
+      expect(() => selectReferingNextStep(buildState())).toThrow();
+    });
+  });
+
+  describe('selectIsFirstReferingStep', () => {
+    it('is true on the first step', () => {
+      expect(
+        selectIsFirstReferingStep(buildState({ currentStep: 'step-1' }))
+      ).toBe(true);
+    });
+
+    it('is false on any other step', () => {
+      expect(
+        selectIsFirstReferingStep(buildState({ currentStep: 'step-2' }))
+      ).toBe(false);
+    });
+
+    it('is false when there is no current step', () => {
+      expect(selectIsFirstReferingStep(buildState())).toBe(false);
+    });
+  });
+
+  describe('selectIsLastReferingStep', () => {
+    it('is false on the first step', () => {
+      expect(
+        selectIsLastReferingStep(buildState({ currentStep: 'step-1' }))
+      ).toBe(false);
+    });
+
+    it('is false when a next step is configured', () => {
+      expect(
+        selectIsLastReferingStep(buildState({ currentStep: 'step-2' }))
+      ).toBe(false);
+    });
+
+    it('is true when no next step is configured', () => {
+      expect(
+        selectIsLastReferingStep(buildState({ currentStep: 'step-4' }))
+      ).toBe(true);
+    });
+
+    it('throws when there is no current step', () => {
+      expect(() => selectIsLastReferingStep(buildState())).toThrow();
+    });
+  });
+
+  describe('selectIsReferingLoading', () => {
+    it('returns the loading flag', () => {
+      expect(selectIsReferingLoading(buildState({ isLoading: true }))).toBe(
+        true
+      );
+      expect(selectIsReferingLoading(buildState({ isLoading: false }))).toBe(
+        false
+      );
+    });
+  });
+
+  describe('selectReferingCurrentStepData', () => {
+    it('returns the data stored for the current step', () => {
+      const state = buildState({
+        currentStep: 'step-1',
+        data: { 'step-1': { firstName: 'Jean' } },
+      });
+
+      expect(selectReferingCurrentStepData(state)).toEqual({
+        firstName: 'Jean',
+      });
+    });
+
+    it('returns null when there is no data for the current step yet', () => {
+      expect(
+        selectReferingCurrentStepData(buildState({ currentStep: 'step-1' }))
+      ).toBeNull();
+    });
+
+    it('throws when there is no current step', () => {
+      expect(() => selectReferingCurrentStepData(buildState())).toThrow();
+    });
+  });
+
+  describe('selectReferingCurrentStepContent', () => {
+    it('returns the content configured for the current step', () => {
+      const content = selectReferingCurrentStepContent(
+        buildState({ currentStep: 'step-1' })
+      );
+
+      expect(content.form.id).toBe('form-refering-account');
+    });
+
+    it('throws when the current step has no configured content', () => {
+      expect(() =>
+        selectReferingCurrentStepContent(
+          buildState({ currentStep: 'step-99' as any })
+        )
+      ).toThrow();
+    });
+
+    it('throws when there is no current step', () => {
+      expect(() => selectReferingCurrentStepContent(buildState())).toThrow();
+    });
+  });
+
+  describe('selectReferingConfirmationStepContent', () => {
+    it('returns the last step content, regardless of state', () => {
+      expect(selectReferingConfirmationStepContent()).toBe(LastStepContent);
+    });
+  });
+
+  describe('selectReferingDataFromOtherStep', () => {
+    it('returns null on the first step', () => {
+      expect(
+        selectReferingDataFromOtherStep(buildState({ currentStep: 'step-1' }))
+      ).toBeNull();
+    });
+
+    it('returns null when the step does not depend on other steps', () => {
+      expect(
+        selectReferingDataFromOtherStep(buildState({ currentStep: 'step-3' }))
+      ).toBeNull();
+    });
+
+    it('flattens the values of the depended-on keys from other steps', () => {
+      const state = buildState({
+        currentStep: 'step-2',
+        data: {
+          'step-1': { gender: Genders.MALE },
+          'step-2': { nudgeIds: ['nudge-1'] },
+        },
+      });
+
+      expect(selectReferingDataFromOtherStep(state)).toEqual({
+        gender: Genders.MALE,
+        nudgeIds: ['nudge-1'],
+      });
+    });
+  });
+
+  describe('selectReferingShouldSkipStep', () => {
+    it('is false on the first step', () => {
+      expect(
+        selectReferingShouldSkipStep(buildState({ currentStep: 'step-1' }))
+      ).toBe(false);
+    });
+
+    it('is false when the step has no skippedBy configuration', () => {
+      expect(
+        selectReferingShouldSkipStep(buildState({ currentStep: 'step-3' }))
+      ).toBe(false);
+    });
+
+    it('skips the step when a scalar depended-on value matches skippedBy', () => {
+      const state = buildState({
+        currentStep: 'step-2',
+        data: { 'step-1': { gender: Genders.FEMALE } },
+      });
+
+      expect(selectReferingShouldSkipStep(state)).toBe(true);
+    });
+
+    it('skips the step when an array depended-on value equals skippedBy', () => {
+      const state = buildState({
+        currentStep: 'step-2',
+        data: { 'step-2': { nudgeIds: ['nudge-1'] } },
+      });
+
+      expect(selectReferingShouldSkipStep(state)).toBe(true);
+    });
+
+    it('does not skip the step when no depended-on value matches skippedBy', () => {
+      const state = buildState({
+        currentStep: 'step-2',
+        data: {
+          'step-1': { gender: Genders.OTHER },
+          'step-2': { nudgeIds: ['nudge-2'] },
+        },
+      });
+
+      expect(selectReferingShouldSkipStep(state)).toBe(false);
+    });
+  });
+});

--- a/src/use-cases/refering/refering.slice.spec.ts
+++ b/src/use-cases/refering/refering.slice.spec.ts
@@ -1,0 +1,197 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { Genders } from '@/src/constants/genders';
+import { ReferingErrorMessages } from '@/src/features/backoffice/referer/Refering/Refering.types';
+import { slice } from './refering.slice';
+
+const { actions, reducer } = slice;
+
+// `setReferingCurrentStepData`'s payload type is the full `ReferingFormData`
+// union (one member per step form), never a partial — the real app always
+// dispatches a step's whole submitted form. This builds a full, valid
+// `step-1` (account) form submission.
+const buildAccountFormData = (
+  overrides: Partial<{
+    firstName: string;
+    lastName: string;
+    gender: Genders;
+    phone: string;
+    email: string;
+    confirmReferingRules: boolean;
+  }> = {}
+) => ({
+  firstName: 'Jean',
+  lastName: 'Dupont',
+  gender: Genders.MALE,
+  phone: '+33612345678',
+  email: 'jean@example.com',
+  confirmReferingRules: true,
+  ...overrides,
+});
+
+describe('refering slice', () => {
+  describe('referCandidateSucceeded', () => {
+    it('only transitions the request status', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        referCandidateError: 'DUPLICATE_EMAIL' as const,
+      };
+
+      const state = reducer(initialState, actions.referCandidateSucceeded());
+
+      expect(state.referCandate.status).toBe('SUCCEEDED');
+      // referCandidateSucceeded has no custom merge logic: pre-existing
+      // error state is left untouched (only referCandidateFailed clears it).
+      expect(state.referCandidateError).toBe('DUPLICATE_EMAIL');
+    });
+  });
+
+  describe('referCandidateFailed', () => {
+    it('stores the error and stops loading', () => {
+      const initialState = { ...slice.getInitialState(), isLoading: true };
+
+      const state = reducer(
+        initialState,
+        actions.referCandidateFailed({ error: 'DUPLICATE_EMAIL' })
+      );
+
+      expect(state.referCandate.status).toBe('FAILED');
+      expect(state.referCandidateError).toBe('DUPLICATE_EMAIL');
+      expect(state.isLoading).toBe(false);
+    });
+
+    it('clears the error when failing without a payload', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        isLoading: true,
+        referCandidateError: 'DUPLICATE_EMAIL' as const,
+      };
+
+      const state = reducer(initialState, actions.referCandidateFailed(null));
+
+      expect(state.referCandidateError).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('setReferingCurrentStepData', () => {
+    it('throws when there is no current step', () => {
+      const initialState = slice.getInitialState();
+
+      expect(() =>
+        reducer(
+          initialState,
+          actions.setReferingCurrentStepData(buildAccountFormData())
+        )
+      ).toThrow(ReferingErrorMessages.CURRENT_STEP);
+    });
+
+    it('stores the payload under the current step when there is no existing data', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 'step-1' as const,
+      };
+      const payload = buildAccountFormData();
+
+      const state = reducer(
+        initialState,
+        actions.setReferingCurrentStepData(payload)
+      );
+
+      expect(state.data['step-1']).toEqual(payload);
+    });
+
+    it('replaces a previous submission for the current step when resubmitted', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 'step-1' as const,
+        // `data` is keyed by `ReferingStep` string (e.g. 'step-1') at
+        // runtime — the type's numeric index signature only accepts that
+        // through a cast, matching how the production reducer itself reads
+        // `state.data[currentStep]`.
+        data: {
+          'step-1': buildAccountFormData({ lastName: 'Ancien' }),
+        } as any,
+      };
+      const payload = buildAccountFormData({ lastName: 'Martin' });
+
+      const state = reducer(
+        initialState,
+        actions.setReferingCurrentStepData(payload)
+      );
+
+      expect(state.data['step-1']).toEqual(payload);
+    });
+
+    it('does not affect data stored under other steps', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 'step-2' as const,
+        data: { 'step-1': buildAccountFormData() } as any,
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setReferingCurrentStepData({ nudgeIds: ['nudge-1'] })
+      );
+
+      expect(state.data['step-1']).toEqual(buildAccountFormData());
+      expect(state.data['step-2']).toEqual({ nudgeIds: ['nudge-1'] });
+    });
+  });
+
+  describe('setReferingStep', () => {
+    it('sets the current step and starts loading', () => {
+      const initialState = { ...slice.getInitialState(), isLoading: false };
+
+      const state = reducer(initialState, actions.setReferingStep('step-2'));
+
+      expect(state.currentStep).toBe('step-2');
+      expect(state.isLoading).toBe(true);
+    });
+
+    it('can reset the current step to null while still flagging loading', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: 'step-2' as const,
+        isLoading: false,
+      };
+
+      const state = reducer(initialState, actions.setReferingStep(null));
+
+      expect(state.currentStep).toBeNull();
+      expect(state.isLoading).toBe(true);
+    });
+  });
+
+  describe('setReferingIsLoading', () => {
+    it('sets isLoading to true', () => {
+      const state = reducer(undefined, actions.setReferingIsLoading(true));
+
+      expect(state.isLoading).toBe(true);
+    });
+
+    it('sets isLoading to false', () => {
+      const initialState = { ...slice.getInitialState(), isLoading: true };
+
+      const state = reducer(initialState, actions.setReferingIsLoading(false));
+
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('resetReferingData', () => {
+    it('clears the collected data and flags loading', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        data: { 'step-1': buildAccountFormData() } as any,
+        isLoading: false,
+      };
+
+      const state = reducer(initialState, actions.resetReferingData());
+
+      expect(state.data).toEqual({});
+      expect(state.isLoading).toBe(true);
+    });
+  });
+});

--- a/src/use-cases/registration/registration.saga.spec.ts
+++ b/src/use-cases/registration/registration.saga.spec.ts
@@ -1,0 +1,324 @@
+jest.mock('@/src/api');
+
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { RegistrationFlow } from '@/src/features/registration/flows/flows.types';
+import { RegistrationData } from '@/src/features/registration/registration.types';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { slice } from './registration.slice';
+
+const { actions } = slice;
+const mockedApi = getMockedApi();
+
+function buildAxiosError(status: number) {
+  return {
+    isAxiosError: true,
+    response: { status },
+  };
+}
+
+const buildRegistrationData = (
+  overrides: Partial<RegistrationData> = {}
+): RegistrationData =>
+  ({
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+    password: 'Sup3rSecret!',
+    confirmPassword: 'Sup3rSecret!',
+    phone: '0600000000',
+    department: { value: 'PARIS', label: 'Paris' },
+    ...overrides,
+  }) as RegistrationData;
+
+describe('registration saga', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+  });
+
+  describe('createUserRequested', () => {
+    it('posts the transformed registration data and succeeds', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Candidat' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      expect(store.getState().registration.createUser.status).toBe('SUCCEEDED');
+      expect(mockedApi.postUserRegistration).toHaveBeenCalledTimes(1);
+      const [payload] = mockedApi.postUserRegistration.mock.calls[0];
+      expect(payload).toMatchObject({
+        firstName: 'Jane',
+        lastName: 'Doe',
+        role: 'Candidat',
+        department: 'PARIS',
+      });
+      expect(payload).not.toHaveProperty('confirmPassword');
+    });
+
+    it('leaves isLoading true after a success (only createUserFailed resets it)', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Candidat' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      expect(store.getState().registration.isLoading).toBe(true);
+    });
+
+    it('extracts organizationId, companyName and companyRole values when provided', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.COMPANY,
+          data: buildRegistrationData({
+            organizationId: { value: 'org-1', label: 'Org 1' },
+            companyName: { value: 'Acme', label: 'Acme' },
+            companyRole: { value: 'MANAGER', label: 'Manager' },
+          } as any),
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Coach' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      const [payload] = mockedApi.postUserRegistration.mock.calls[0];
+      expect(payload).toMatchObject({
+        organizationId: 'org-1',
+        companyName: 'Acme',
+        companyRole: 'MANAGER',
+      });
+    });
+
+    it('reads UTM parameters from localStorage and includes them in the payload', async () => {
+      localStorage.setItem('utm_source', 'google');
+      localStorage.setItem('utm_medium', 'cpc');
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Candidat' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      const [payload] = mockedApi.postUserRegistration.mock.calls[0];
+      expect(payload).toMatchObject({
+        utmSource: 'google',
+        utmMedium: 'cpc',
+      });
+    });
+
+    it('includes nudges, sector occupations and current job from the pre-registration preferences when present', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+          preRegistrationPreferences: {
+            nudgeIds: ['nudge-1', 'nudge-2'],
+            sectorOccupations: [{ id: 'sector-1' }] as any,
+            businessSectorIds: [],
+            currentJob: 'Developer',
+          },
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Candidat' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      const [payload] = mockedApi.postUserRegistration.mock.calls[0];
+      expect(payload).toMatchObject({
+        nudges: [{ id: 'nudge-1' }, { id: 'nudge-2' }],
+        sectorOccupations: [{ id: 'sector-1' }],
+        currentJob: 'Developer',
+      });
+    });
+
+    it('omits nudges, sector occupations and current job when the pre-registration preferences are empty', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+          preRegistrationPreferences: {
+            nudgeIds: [],
+            sectorOccupations: [],
+            businessSectorIds: [],
+            currentJob: undefined,
+          },
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Candidat' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      const [payload] = mockedApi.postUserRegistration.mock.calls[0];
+      expect(payload).not.toHaveProperty('nudges');
+      expect(payload).not.toHaveProperty('sectorOccupations');
+      expect(payload).not.toHaveProperty('currentJob');
+    });
+
+    it('includes the invitationId when one is set', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+          invitationId: 'invitation-1',
+        },
+      });
+      mockedApi.postUserRegistration.mockResolvedValue({
+        data: { id: 'user-1', zone: 'PARIS', role: 'Candidat' },
+      } as any);
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      const [payload] = mockedApi.postUserRegistration.mock.calls[0];
+      expect(payload).toMatchObject({ invitationId: 'invitation-1' });
+    });
+
+    it('dispatches createUserFailed(null) without calling the API when there is no registration data', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: null,
+        },
+      });
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      expect(mockedApi.postUserRegistration).not.toHaveBeenCalled();
+      expect(store.getState().registration.createUser.status).toBe('FAILED');
+      expect(store.getState().registration.createUserError).toBeNull();
+      expect(store.getState().registration.isLoading).toBe(false);
+    });
+
+    it('dispatches createUserFailed with DUPLICATE_EMAIL when the API responds with a 409 conflict', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+        },
+      });
+      mockedApi.postUserRegistration.mockRejectedValue(buildAxiosError(409));
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      expect(store.getState().registration.createUser.status).toBe('FAILED');
+      expect(store.getState().registration.createUserError).toBe(
+        'DUPLICATE_EMAIL'
+      );
+      expect(store.getState().registration.isLoading).toBe(false);
+    });
+
+    it('dispatches createUserFailed(null) when the API call rejects with a non-conflict error', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          data: buildRegistrationData(),
+        },
+      });
+      mockedApi.postUserRegistration.mockRejectedValue(new Error('boom'));
+
+      store.dispatch(actions.createUserRequested());
+      await flushPromises();
+
+      expect(store.getState().registration.createUser.status).toBe('FAILED');
+      expect(store.getState().registration.createUserError).toBeNull();
+      expect(store.getState().registration.isLoading).toBe(false);
+    });
+  });
+
+  describe('moveForwardInRegistration', () => {
+    it('sets isLoading, then clears it again after the transition delay when registration is not ended', async () => {
+      const store = createTestStore({
+        registration: { ...slice.getInitialState(), isEnded: false },
+      });
+
+      store.dispatch(actions.moveForwardInRegistration({ step: 1 }));
+      await flushPromises();
+      expect(store.getState().registration.isLoading).toBe(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      expect(store.getState().registration.isLoading).toBe(false);
+    });
+
+    it('sets isLoading and leaves it set when registration has ended', async () => {
+      const store = createTestStore({
+        registration: { ...slice.getInitialState(), isEnded: true },
+      });
+
+      store.dispatch(actions.moveForwardInRegistration({ step: 1 }));
+      await flushPromises();
+
+      expect(store.getState().registration.isLoading).toBe(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      expect(store.getState().registration.isLoading).toBe(true);
+    });
+  });
+
+  describe('resetRegistrationData', () => {
+    it('resets the registration state and toggles isLoading through the reset delay', async () => {
+      const store = createTestStore({
+        registration: {
+          ...slice.getInitialState(),
+          selectedFlow: RegistrationFlow.CANDIDATE,
+          currentStep: 2,
+          data: buildRegistrationData(),
+        },
+      });
+
+      store.dispatch(actions.resetRegistrationData());
+      await flushPromises();
+
+      expect(store.getState().registration.selectedFlow).toBeNull();
+      expect(store.getState().registration.currentStep).toBe(-1);
+      expect(store.getState().registration.data).toBeNull();
+      expect(store.getState().registration.isLoading).toBe(true);
+
+      await new Promise((resolve) => setTimeout(resolve, 350));
+      expect(store.getState().registration.isLoading).toBe(false);
+    });
+  });
+});

--- a/src/use-cases/registration/registration.selectors.spec.ts
+++ b/src/use-cases/registration/registration.selectors.spec.ts
@@ -1,0 +1,292 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { RegistrationFlow } from '@/src/features/registration/flows/flows.types';
+import {
+  RegistrationFlows,
+  RegistrationStepSelectFlow,
+} from '@/src/features/registration/registration.config';
+import { RegistrationData } from '@/src/features/registration/registration.types';
+import {
+  selectCompatibleProfilesCount,
+  selectCreateUserError,
+  selectDefinedRegistrationSelectedFlow,
+  selectInvitationId,
+  selectIsFirstRegistrationStep,
+  selectIsRegistrationLoading,
+  selectNextIsLastRegistrationStep,
+  selectPreRegistrationPreferences,
+  selectRegistrationCurrentStep,
+  selectRegistrationCurrentStepContent,
+  selectRegistrationData,
+  selectRegistrationIsEnded,
+  selectRegistrationNextStep,
+  selectRegistrationSelectedFlow,
+  selectRegistrationShouldSkipStep,
+} from './registration.selectors';
+import { RootState, slice } from './registration.slice';
+
+const buildState = (
+  overrides: Partial<ReturnType<typeof slice.getInitialState>> = {}
+): RootState =>
+  ({
+    registration: { ...slice.getInitialState(), ...overrides },
+  }) as RootState;
+
+const buildRegistrationData = (
+  overrides: Partial<RegistrationData> = {}
+): RegistrationData =>
+  ({
+    firstName: 'Jane',
+    ...overrides,
+  }) as RegistrationData;
+
+describe('registration.selectors', () => {
+  describe('selectCreateUserError', () => {
+    it('returns the create user error', () => {
+      expect(
+        selectCreateUserError(
+          buildState({ createUserError: 'DUPLICATE_EMAIL' })
+        )
+      ).toBe('DUPLICATE_EMAIL');
+    });
+
+    it('returns null when there is no error', () => {
+      expect(selectCreateUserError(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectInvitationId', () => {
+    it('returns the invitation id', () => {
+      expect(
+        selectInvitationId(buildState({ invitationId: 'invitation-1' }))
+      ).toBe('invitation-1');
+    });
+
+    it('returns undefined when there is no invitation id', () => {
+      expect(selectInvitationId(buildState())).toBeUndefined();
+    });
+  });
+
+  describe('selectRegistrationData', () => {
+    it('returns the registration data', () => {
+      const data = buildRegistrationData();
+      expect(selectRegistrationData(buildState({ data }))).toEqual(data);
+    });
+
+    it('returns null when there is no data yet', () => {
+      expect(selectRegistrationData(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectRegistrationCurrentStep', () => {
+    it('returns the current step', () => {
+      expect(
+        selectRegistrationCurrentStep(buildState({ currentStep: 2 }))
+      ).toBe(2);
+    });
+  });
+
+  describe('selectRegistrationNextStep', () => {
+    it('returns the current step incremented by one', () => {
+      expect(selectRegistrationNextStep(buildState({ currentStep: 1 }))).toBe(
+        2
+      );
+    });
+
+    it('throws when the current step is not defined', () => {
+      expect(() =>
+        selectRegistrationNextStep(
+          buildState({ currentStep: undefined as any })
+        )
+      ).toThrow();
+    });
+  });
+
+  describe('selectRegistrationSelectedFlow', () => {
+    it('returns the selected flow', () => {
+      expect(
+        selectRegistrationSelectedFlow(
+          buildState({ selectedFlow: RegistrationFlow.CANDIDATE })
+        )
+      ).toBe(RegistrationFlow.CANDIDATE);
+    });
+
+    it('returns null when no flow is selected', () => {
+      expect(selectRegistrationSelectedFlow(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectDefinedRegistrationSelectedFlow', () => {
+    it('returns the selected flow when set', () => {
+      expect(
+        selectDefinedRegistrationSelectedFlow(
+          buildState({ selectedFlow: RegistrationFlow.COACH })
+        )
+      ).toBe(RegistrationFlow.COACH);
+    });
+
+    it('returns null without throwing when no flow is selected', () => {
+      expect(selectDefinedRegistrationSelectedFlow(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectIsFirstRegistrationStep', () => {
+    it('returns true when on the first step', () => {
+      expect(
+        selectIsFirstRegistrationStep(buildState({ currentStep: 0 }))
+      ).toBe(true);
+    });
+
+    it('returns false when not on the first step', () => {
+      expect(
+        selectIsFirstRegistrationStep(buildState({ currentStep: 1 }))
+      ).toBe(false);
+    });
+  });
+
+  describe('selectNextIsLastRegistrationStep', () => {
+    it('returns false when no flow is selected', () => {
+      expect(
+        selectNextIsLastRegistrationStep(buildState({ currentStep: 0 }))
+      ).toBe(false);
+    });
+
+    it('returns false when the next step is not the last one', () => {
+      // REFERER flow has a single step, so from step -1 the next step (0) is already the last one.
+      // CANDIDATE flow has 3 steps, so from step 0 the next step (1) is not the last one.
+      expect(
+        selectNextIsLastRegistrationStep(
+          buildState({
+            selectedFlow: RegistrationFlow.CANDIDATE,
+            currentStep: 0,
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('returns true when the next step reaches or exceeds the last step of the flow', () => {
+      // REFERER flow has a single step (length 1): from currentStep 0, the
+      // next step (1) already reaches the flow's length, so it counts as last.
+      const flowLength = RegistrationFlows[RegistrationFlow.REFERER]!.length;
+
+      expect(
+        selectNextIsLastRegistrationStep(
+          buildState({
+            selectedFlow: RegistrationFlow.REFERER,
+            currentStep: flowLength - 1,
+          })
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe('selectRegistrationIsEnded', () => {
+    it('returns the isEnded flag', () => {
+      expect(selectRegistrationIsEnded(buildState({ isEnded: true }))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('selectPreRegistrationPreferences', () => {
+    it('returns the pre-registration preferences', () => {
+      const preRegistrationPreferences = {
+        nudgeIds: ['nudge-1'],
+        sectorOccupations: [],
+        businessSectorIds: [],
+        currentJob: undefined,
+      };
+
+      expect(
+        selectPreRegistrationPreferences(
+          buildState({ preRegistrationPreferences })
+        )
+      ).toEqual(preRegistrationPreferences);
+    });
+
+    it('returns null when there are no preferences yet', () => {
+      expect(selectPreRegistrationPreferences(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectIsRegistrationLoading', () => {
+    it('returns the isLoading flag', () => {
+      expect(selectIsRegistrationLoading(buildState({ isLoading: true }))).toBe(
+        true
+      );
+    });
+  });
+
+  describe('selectCompatibleProfilesCount', () => {
+    it('returns the compatible profiles count', () => {
+      expect(
+        selectCompatibleProfilesCount(
+          buildState({ compatibleProfilesCount: 7 })
+        )
+      ).toBe(7);
+    });
+
+    it('returns null when not set', () => {
+      expect(selectCompatibleProfilesCount(buildState())).toBeNull();
+    });
+  });
+
+  describe('selectRegistrationCurrentStepContent', () => {
+    it('returns the flow selection step when no flow is selected', () => {
+      expect(
+        selectRegistrationCurrentStepContent(buildState({ currentStep: 0 }))
+      ).toBe(RegistrationStepSelectFlow);
+    });
+
+    it('returns the current step content for the selected flow', () => {
+      expect(
+        selectRegistrationCurrentStepContent(
+          buildState({
+            selectedFlow: RegistrationFlow.CANDIDATE,
+            currentStep: 1,
+          })
+        )
+      ).toBe(RegistrationFlows[RegistrationFlow.CANDIDATE]![1]);
+    });
+
+    it('falls back to the flow selection step when the current step is out of range', () => {
+      expect(
+        selectRegistrationCurrentStepContent(
+          buildState({
+            selectedFlow: RegistrationFlow.REFERER,
+            currentStep: 99,
+          })
+        )
+      ).toBe(RegistrationStepSelectFlow);
+    });
+  });
+
+  describe('selectRegistrationShouldSkipStep', () => {
+    it('returns false when there is no registration data yet', () => {
+      expect(
+        selectRegistrationShouldSkipStep(
+          buildState({
+            selectedFlow: RegistrationFlow.CANDIDATE,
+            currentStep: 0,
+            data: null,
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('returns false when the current step content has no skippedBy configuration', () => {
+      // None of the steps configured in RegistrationFlows currently define
+      // `skippedBy`, so this is the only reachable branch of the selector
+      // with real registration config data.
+      expect(
+        selectRegistrationShouldSkipStep(
+          buildState({
+            selectedFlow: RegistrationFlow.CANDIDATE,
+            currentStep: 0,
+            data: buildRegistrationData(),
+          })
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/src/use-cases/registration/registration.slice.spec.ts
+++ b/src/use-cases/registration/registration.slice.spec.ts
@@ -1,0 +1,387 @@
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { RegistrationFlow } from '@/src/features/registration/flows/flows.types';
+import { REGISTRATION_FIRST_STEP } from '@/src/features/registration/registration.config';
+import { RegistrationData } from '@/src/features/registration/registration.types';
+import { slice } from './registration.slice';
+
+const { actions, reducer } = slice;
+
+// `NonNullable<RegistrationData>` (rather than `RegistrationData`, which also
+// allows `null`) so this fixture is assignable both to the slice's `data`
+// state field and to `moveForwardInRegistration`'s `data?: RegistrationFormData`
+// payload.
+const buildRegistrationData = (
+  overrides: Partial<RegistrationData> = {}
+): NonNullable<RegistrationData> =>
+  ({
+    firstName: 'Jane',
+    lastName: 'Doe',
+    email: 'jane@example.com',
+    department: { value: 'PARIS', label: 'Paris' },
+    ...overrides,
+  }) as NonNullable<RegistrationData>;
+
+describe('registration slice', () => {
+  describe('createUser request lifecycle', () => {
+    it('createUserRequested sets isLoading and clears the previous error', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        createUserError: 'DUPLICATE_EMAIL' as const,
+      };
+
+      const state = reducer(initialState, actions.createUserRequested());
+
+      expect(state.isLoading).toBe(true);
+      expect(state.createUserError).toBeNull();
+      expect(state.createUser.status).toBe('REQUESTED');
+    });
+
+    it('createUserSucceeded only transitions the request status', () => {
+      const initialState = { ...slice.getInitialState(), isLoading: true };
+
+      const state = reducer(initialState, actions.createUserSucceeded());
+
+      expect(state.createUser.status).toBe('SUCCEEDED');
+      expect(state.isLoading).toBe(true);
+    });
+
+    it('createUserFailed sets isLoading to false and stores the error', () => {
+      const state = reducer(
+        undefined,
+        actions.createUserFailed({ error: 'DUPLICATE_EMAIL' })
+      );
+
+      expect(state.isLoading).toBe(false);
+      expect(state.createUserError).toBe('DUPLICATE_EMAIL');
+      expect(state.createUser.status).toBe('FAILED');
+    });
+
+    it('createUserFailed clears the error when no payload is given', () => {
+      const state = reducer(undefined, actions.createUserFailed(null));
+
+      expect(state.createUserError).toBeNull();
+    });
+  });
+
+  describe('moveForwardInRegistration', () => {
+    it('sets the selected flow when provided', () => {
+      const state = reducer(
+        undefined,
+        actions.moveForwardInRegistration({ flow: RegistrationFlow.CANDIDATE })
+      );
+
+      expect(state.selectedFlow).toBe(RegistrationFlow.CANDIDATE);
+    });
+
+    it('does not merge data on the same action that first sets the flow (selectedFlow is read before the flow is applied)', () => {
+      const data = buildRegistrationData();
+
+      const state = reducer(
+        undefined,
+        actions.moveForwardInRegistration({
+          flow: RegistrationFlow.CANDIDATE,
+          data,
+        })
+      );
+
+      expect(state.selectedFlow).toBe(RegistrationFlow.CANDIDATE);
+      expect(state.data).toBeNull();
+    });
+
+    it('sets data as-is when there was none yet and a flow is already selected', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedFlow: RegistrationFlow.CANDIDATE,
+      };
+      const data = buildRegistrationData();
+
+      const state = reducer(
+        initialState,
+        actions.moveForwardInRegistration({ data })
+      );
+
+      expect(state.data).toEqual(data);
+    });
+
+    it('merges new data into existing data when a flow is already selected', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedFlow: RegistrationFlow.CANDIDATE,
+        data: buildRegistrationData({ firstName: 'Old' }),
+      };
+
+      const state = reducer(
+        initialState,
+        actions.moveForwardInRegistration({
+          data: buildRegistrationData({
+            firstName: 'New',
+            lastName: 'Updated',
+          }),
+        })
+      );
+
+      expect(state.data).toEqual(
+        buildRegistrationData({ firstName: 'New', lastName: 'Updated' })
+      );
+    });
+
+    it('ignores data when no flow has ever been selected', () => {
+      const state = reducer(
+        undefined,
+        actions.moveForwardInRegistration({ data: buildRegistrationData() })
+      );
+
+      expect(state.data).toBeNull();
+    });
+
+    it('updates the current step when provided', () => {
+      const state = reducer(
+        undefined,
+        actions.moveForwardInRegistration({ step: 2 })
+      );
+
+      expect(state.currentStep).toBe(2);
+    });
+
+    it('leaves the current step untouched when not provided', () => {
+      const initialState = { ...slice.getInitialState(), currentStep: 3 };
+
+      const state = reducer(
+        initialState,
+        actions.moveForwardInRegistration({ flow: RegistrationFlow.COACH })
+      );
+
+      expect(state.currentStep).toBe(3);
+    });
+  });
+
+  it('setRegistrationIsLoading sets the isLoading flag', () => {
+    const state = reducer(undefined, actions.setRegistrationIsLoading(true));
+
+    expect(state.isLoading).toBe(true);
+  });
+
+  describe('moveBackwardInRegistration', () => {
+    it('decrements the current step when above the first step', () => {
+      const initialState = { ...slice.getInitialState(), currentStep: 2 };
+
+      const state = reducer(initialState, actions.moveBackwardInRegistration());
+
+      expect(state.currentStep).toBe(1);
+    });
+
+    it('does nothing when already at the first step', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        currentStep: REGISTRATION_FIRST_STEP,
+      };
+
+      const state = reducer(initialState, actions.moveBackwardInRegistration());
+
+      expect(state.currentStep).toBe(REGISTRATION_FIRST_STEP);
+    });
+
+    it('does nothing when below the first step (no flow selected yet)', () => {
+      const state = reducer(undefined, actions.moveBackwardInRegistration());
+
+      expect(state.currentStep).toBe(-1);
+    });
+  });
+
+  describe('setPreRegistrationPreferences', () => {
+    it('fills in defaults for fields not yet set when there were no preferences', () => {
+      const state = reducer(
+        undefined,
+        actions.setPreRegistrationPreferences({ nudgeIds: ['nudge-1'] })
+      );
+
+      expect(state.preRegistrationPreferences).toEqual({
+        nudgeIds: ['nudge-1'],
+        sectorOccupations: [],
+        businessSectorIds: [],
+        currentJob: undefined,
+      });
+    });
+
+    it('preserves previously set fields that are not included in the new payload', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        preRegistrationPreferences: {
+          nudgeIds: ['nudge-1'],
+          sectorOccupations: [{ id: 'sector-1' }] as any,
+          businessSectorIds: ['business-1'],
+          currentJob: 'Developer',
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setPreRegistrationPreferences({ currentJob: 'Manager' })
+      );
+
+      expect(state.preRegistrationPreferences).toEqual({
+        nudgeIds: ['nudge-1'],
+        sectorOccupations: [{ id: 'sector-1' }],
+        businessSectorIds: ['business-1'],
+        currentJob: 'Manager',
+      });
+    });
+
+    it('overrides a field with a new empty array instead of falling back to the previous value', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        preRegistrationPreferences: {
+          nudgeIds: ['nudge-1'],
+          sectorOccupations: [],
+          businessSectorIds: [],
+          currentJob: undefined,
+        },
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setPreRegistrationPreferences({ nudgeIds: [] })
+      );
+
+      expect(state.preRegistrationPreferences?.nudgeIds).toEqual([]);
+    });
+  });
+
+  it('setCompatibleProfilesCount sets the compatible profiles count', () => {
+    const state = reducer(undefined, actions.setCompatibleProfilesCount(42));
+
+    expect(state.compatibleProfilesCount).toBe(42);
+  });
+
+  describe('resetRegistrationData', () => {
+    it('resets the flow, step, data, ended flag, preferences and compatible profiles count', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedFlow: RegistrationFlow.CANDIDATE,
+        currentStep: 2,
+        data: buildRegistrationData(),
+        isEnded: true,
+        preRegistrationPreferences: {
+          nudgeIds: ['nudge-1'],
+          sectorOccupations: [],
+          businessSectorIds: [],
+          currentJob: 'Dev',
+        },
+        compatibleProfilesCount: 5,
+      };
+
+      const state = reducer(initialState, actions.resetRegistrationData());
+
+      expect(state.selectedFlow).toBeNull();
+      expect(state.currentStep).toBe(-1);
+      expect(state.data).toBeNull();
+      expect(state.isEnded).toBe(false);
+      expect(state.preRegistrationPreferences).toBeNull();
+      expect(state.compatibleProfilesCount).toBeNull();
+    });
+
+    it('leaves invitationId and the createUser request state untouched', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        invitationId: 'invitation-1',
+        isLoading: true,
+      };
+
+      const state = reducer(initialState, actions.resetRegistrationData());
+
+      expect(state.invitationId).toBe('invitation-1');
+      expect(state.isLoading).toBe(true);
+    });
+  });
+
+  it('setRegistrationIsEnded sets the isEnded flag', () => {
+    const state = reducer(undefined, actions.setRegistrationIsEnded(true));
+
+    expect(state.isEnded).toBe(true);
+  });
+
+  describe('setStateFromQueryParams', () => {
+    it('sets the selected flow and resets to the first step when a flow is provided', () => {
+      const initialState = { ...slice.getInitialState(), currentStep: 3 };
+
+      const state = reducer(
+        initialState,
+        actions.setStateFromQueryParams({ flow: RegistrationFlow.COACH })
+      );
+
+      expect(state.selectedFlow).toBe(RegistrationFlow.COACH);
+      expect(state.currentStep).toBe(REGISTRATION_FIRST_STEP);
+    });
+
+    it('leaves the selected flow and current step untouched when no flow is provided', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        selectedFlow: RegistrationFlow.CANDIDATE,
+        currentStep: 3,
+      };
+
+      const state = reducer(initialState, actions.setStateFromQueryParams({}));
+
+      expect(state.selectedFlow).toBe(RegistrationFlow.CANDIDATE);
+      expect(state.currentStep).toBe(3);
+    });
+
+    it('sets a companyName field in data when provided and there was no data yet', () => {
+      const state = reducer(
+        undefined,
+        actions.setStateFromQueryParams({ companyName: 'Acme' })
+      );
+
+      expect(state.data).toEqual({
+        companyName: { value: 'Acme', label: 'Acme' },
+      });
+    });
+
+    it('merges the companyName field into existing data', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        data: buildRegistrationData({ firstName: 'Jane' }),
+      };
+
+      const state = reducer(
+        initialState,
+        actions.setStateFromQueryParams({ companyName: 'Acme' })
+      );
+
+      expect(state.data).toEqual({
+        ...buildRegistrationData({ firstName: 'Jane' }),
+        companyName: { value: 'Acme', label: 'Acme' },
+      });
+    });
+
+    it('does not touch data when no companyName is provided', () => {
+      const state = reducer(
+        undefined,
+        actions.setStateFromQueryParams({ flow: RegistrationFlow.CANDIDATE })
+      );
+
+      expect(state.data).toBeNull();
+    });
+
+    it('sets the invitationId when provided', () => {
+      const state = reducer(
+        undefined,
+        actions.setStateFromQueryParams({ invitationId: 'invitation-1' })
+      );
+
+      expect(state.invitationId).toBe('invitation-1');
+    });
+
+    it('leaves the invitationId untouched when not provided', () => {
+      const initialState = {
+        ...slice.getInitialState(),
+        invitationId: 'invitation-1',
+      };
+
+      const state = reducer(initialState, actions.setStateFromQueryParams({}));
+
+      expect(state.invitationId).toBe('invitation-1');
+    });
+  });
+});


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9314](https://entourage-asso.atlassian.net/browse/EN-9314)
**💬 Commentaire :**

This pull request introduces a comprehensive suite of test utilities and significantly expands the test coverage for Redux store and authentication saga logic. It adds a new `testUtils` directory with helpers for creating a real Redux store, seeding state, and mocking APIs, and includes a detailed integration test for the authentication saga. Additionally, it improves request state handling and testing in the `createRequestAdapter` utility.

**New test utilities and infrastructure:**

- Added `src/store/testUtils/createTestStore.ts`, which provides a `createTestStore` function to build a real Redux store with all use-case reducers and sagas for use in tests. This ensures tests exercise actual store behavior rather than mocks.
- Added `src/store/testUtils/flushPromises.ts` for awaiting saga side effects in tests, `src/store/testUtils/mockApi.ts` for type-safe access to the mocked `Api` singleton, and `src/store/testUtils/seedAccessToken.ts` for seeding `localStorage` with an access token. [[1]](diffhunk://#diff-297c424a7e38a1a97c6beb584183245684da0a1b8dffa16b2c2119d8687d5172R1-R9) [[2]](diffhunk://#diff-b92ad25fc7670eae7a67b9d5bb276c5d499137ab1539caaf0a3b3ef58be77217R1-R12) [[3]](diffhunk://#diff-688478a8af96a68247ef6781b54d770d44a66ffe0bd6cf50f406f5debe50ccabR1-R14)
- Added `src/store/testUtils/renderWithProviders.tsx` to simplify rendering React components with a real Redux provider during tests.
- Updated ESLint config to ignore files in the new `testUtils` directory.

**Authentication saga integration tests:**

- Added `src/use-cases/authentication/authentication.saga.spec.ts`, a thorough integration test for the authentication saga. It tests access token initialization, login/logout flows, error handling (including specific error codes), email verification, OTP verification, and cross-domain saga interactions.

**Improvements to request adapter and tests:**

- Enhanced the `createRequestAdapter` test to track error reasons in state, verify error propagation on failed actions, and test request state reset behavior. [[1]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aL15-R26) [[2]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aR38-R40) [[3]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aL133-R150) [[4]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aR159) [[5]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aR187-R220)

These changes together provide a robust foundation for writing integration tests against the Redux store and sagas, improving confidence in authentication and related flows.

**References:**  
[[1]](diffhunk://#diff-8f35d21f113766c9964b613be450d366cff2510babf527efe4fc9d7d7dbd2ff8R1-R113) [[2]](diffhunk://#diff-297c424a7e38a1a97c6beb584183245684da0a1b8dffa16b2c2119d8687d5172R1-R9) [[3]](diffhunk://#diff-b92ad25fc7670eae7a67b9d5bb276c5d499137ab1539caaf0a3b3ef58be77217R1-R12) [[4]](diffhunk://#diff-688478a8af96a68247ef6781b54d770d44a66ffe0bd6cf50f406f5debe50ccabR1-R14) [[5]](diffhunk://#diff-05bce165c433f695e409d27d91565f7be74de09bba79593593e98510e396dafeR1-R32) [[6]](diffhunk://#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R224) [[7]](diffhunk://#diff-aa0f3c9b6d5d36d58de2a93cb83acb31c19e2cf12ae347e68511aca7431802acR1-R320) [[8]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aL15-R26) [[9]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aR38-R40) [[10]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aL133-R150) [[11]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aR159) [[12]](diffhunk://#diff-103c85a59dd03c2b0380c79d7d0a0d3936de8e517bbafc1270f2c7b3c058929aR187-R220)

[EN-9314]: https://entourage-asso.atlassian.net/browse/EN-9314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ