### PR TITLE
Add paramsSerializer configuration option for Axios

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -53,6 +53,7 @@ export class APIHandler {
         Accept: 'application/json',
         'Content-Type': 'application/json',
       },
+      paramsSerializer: { indexes: null },
     });
     addAxiosInterceptors(this.api);
   }


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9307](https://entourage-asso.atlassian.net/browse/EN-9307)
**🚧 PR-Back :** [back/512](https://github.com/ReseauEntourage/entourage-job-back/pull/512)
**💬 Commentaire :**

This pull request makes a small configuration change to the `APIHandler` class to improve how query parameters are serialized in API requests.

- Added the `paramsSerializer: { indexes: null }` option to the Axios instance configuration in `src/api/api.ts`, which disables array indexes in serialized query parameters.

[EN-9307]: https://entourage-asso.atlassian.net/browse/EN-9307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ