### PR TITLE
Refactor layout styles for desktop and mobile, remove unused classes

### DIFF
--- a/src/components/ui/Inputs/TextArea/TextArea.styles.tsx
+++ b/src/components/ui/Inputs/TextArea/TextArea.styles.tsx
@@ -23,7 +23,6 @@ export const StyledTextArea = styled.textarea<{
   $hasLineLimit: boolean;
   $textAreaWidth?: number;
   width: number;
-  $device: 'mobile' | 'desktop';
   $naked?: boolean;
 }>`
   ${() => commonInputStyles}

--- a/src/components/ui/Inputs/TextArea/TextArea.tsx
+++ b/src/components/ui/Inputs/TextArea/TextArea.tsx
@@ -1,6 +1,5 @@
 import React, { ChangeEvent, useEffect } from 'react';
 import { Text } from '@/src/components/ui';
-import { useIsMobile } from '@/src/hooks/utils';
 import {
   StyledAnnotations,
   StyledAnnotationsErrorMessage,
@@ -47,7 +46,6 @@ export function TextArea({
   setIsMaxLinesReached,
   naked = false,
 }: TextAreaProps) {
-  const isMobile = useIsMobile();
   const { textAreaRef, remainingLines, maxLinesReached, textAreaWidth } =
     useLineLimit(value, name, onChange, maxLines?.lines);
 
@@ -90,7 +88,6 @@ export function TextArea({
         width={maxLinesWidth}
       >
         <StyledTextArea
-          $device={isMobile ? 'mobile' : 'desktop'}
           $hasLineLimit={!!maxLines}
           width={maxLinesWidth}
           $naked={naked}

--- a/src/features/backoffice/messaging/Messaging.styles.tsx
+++ b/src/features/backoffice/messaging/Messaging.styles.tsx
@@ -8,6 +8,7 @@ export const StyledMessagingGridDesktop = styled.div`
   display: flex;
   flex-direction: row;
   height: calc(100vh - ${HEIGHTS.HEADER}px);
+  height: calc(100dvh - ${HEIGHTS.HEADER}px);
   flex: 1;
   border-top: ${HEIGHTS.MESSAGING_DESKTOP_BORDER_SIZE}px solid
     ${COLORS.lightGray};
@@ -21,6 +22,7 @@ export const StyledMessagingGridMobile = styled.div`
   align-items: flex-start;
   width: 100%;
   height: calc(100vh - ${HEIGHTS.HEADER_MOBILE}px);
+  height: calc(100dvh - ${HEIGHTS.HEADER_MOBILE}px);
 `;
 
 export const StyledMessagingLeftPanel = styled.div`
@@ -52,6 +54,7 @@ export const StyledMessagingConversationContainerMobile = styled.div`
 export const MessagingEmptyStateContainerDesktop = styled.div`
   flex: 1;
   height: calc(100vh - ${HEIGHTS.HEADER}px);
+  height: calc(100dvh - ${HEIGHTS.HEADER}px);
   padding: 20px 50px;
 `;
 

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.styles.ts
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.styles.ts
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
-import { COLORS } from '@/src/constants/styles';
+import { BREAKPOINTS, COLORS } from '@/src/constants/styles';
 
 export const MessagingConversationWrapper = styled.div`
   display: flex;
@@ -20,6 +20,10 @@ export const MessagingConversationContainer = styled.div`
   border: ${COLORS.lightGray} 1px solid;
   box-sizing: border-box;
   height: 100%;
+
+  @media (max-width: ${BREAKPOINTS.desktop}px) {
+    min-height: 0;
+  }
 `;
 
 export const MessagingConversationAIPanel = styled.div`

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingConversation.tsx
@@ -305,10 +305,7 @@ export const MessagingConversation = () => {
           participants={selectedConversation?.participants || []}
         />
       ) : (
-        <MessagingMessagesContainer
-          $blur={shouldGiveFeedback}
-          className={isMobile ? 'mobile' : ''}
-        >
+        <MessagingMessagesContainer $blur={shouldGiveFeedback}>
           {reversedMessages &&
             reversedMessages.map((message) => (
               <MessagingMessage key={message.id} message={message} />
@@ -343,7 +340,7 @@ export const MessagingConversation = () => {
 
   if (!selectedConversationId) {
     return (
-      <MessagingConversationContainer className={isMobile ? 'mobile' : ''}>
+      <MessagingConversationContainer>
         <MessagingEmptyState title="Cliquer sur une conversation pour la lire" />
       </MessagingConversationContainer>
     );
@@ -355,7 +352,7 @@ export const MessagingConversation = () => {
 
   return (
     <MessagingConversationWrapper>
-      <MessagingConversationContainer className={isMobile ? 'mobile' : ''}>
+      <MessagingConversationContainer>
         {conversationContent}
       </MessagingConversationContainer>
       {!isMobile &&

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingEditor/MessagingEditor.styles.ts
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingEditor/MessagingEditor.styles.ts
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
-import { COLORS } from '@/src/constants/styles';
+import { BREAKPOINTS, COLORS } from '@/src/constants/styles';
 
 export const MessagingEditorContainer = styled.div`
   display: flex;
@@ -8,7 +8,7 @@ export const MessagingEditorContainer = styled.div`
   padding: 20px 20px 20px 20px;
   gap: 10px;
   box-sizing: border-box;
-  &.mobile {
+  @media (max-width: ${BREAKPOINTS.desktop}px) {
     position: sticky;
     bottom: 0;
   }
@@ -28,7 +28,7 @@ export const MessagingMessageForm = styled.form<{
   background: ${COLORS.lightGray};
   box-sizing: border-box;
   gap: 25px;
-  &.mobile {
+  @media (max-width: ${BREAKPOINTS.desktop}px) {
     position: sticky;
     bottom: 0;
   }

--- a/src/features/backoffice/messaging/MessagingConversation/MessagingEditor/MessagingEditor.tsx
+++ b/src/features/backoffice/messaging/MessagingConversation/MessagingEditor/MessagingEditor.tsx
@@ -133,10 +133,7 @@ export const MessagingEditor = ({ readonly }: MessagingEditorProps) => {
           ))}
         </StyledAttachementInfoContainer>
       )}
-      <MessagingMessageForm
-        $blur={shouldGiveFeedback}
-        className={isMobile ? 'mobile' : ''}
-      >
+      <MessagingMessageForm $blur={shouldGiveFeedback}>
         <FileInput
           id="file-input"
           name="file-input"

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.styles.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.styles.tsx
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
-import { COLORS } from '@/src/constants/styles';
+import { BREAKPOINTS, COLORS } from '@/src/constants/styles';
 
 export const ContainerStyled = styled.div`
   display: flex;
@@ -21,8 +21,9 @@ export const StyledConversationsContainer = styled.div`
   > *:not(:last-child) {
     border-bottom: 1px solid #e0e0e0;
   }
-  &:not(.mobile) {
-    height: 100%;
+  height: 100%;
+  @media (max-width: ${BREAKPOINTS.desktop}px) {
+    height: auto;
   }
 `;
 

--- a/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.tsx
+++ b/src/features/backoffice/messaging/MessagingConversationsList/MessagingConversationList.tsx
@@ -93,7 +93,7 @@ export const MessagingConversationList = () => {
           />
         </StyledSearchBarContainer>
       )}
-      <StyledConversationsContainer className={isMobile ? 'mobile' : ''}>
+      <StyledConversationsContainer>
         {conversations &&
           conversations.length > 0 &&
           conversations.map((conversation) => (

--- a/src/features/companies/CollaboratorSmallCard/CollaboratorSmallCard.styles.ts
+++ b/src/features/companies/CollaboratorSmallCard/CollaboratorSmallCard.styles.ts
@@ -1,4 +1,5 @@
 import { styled } from 'styled-components';
+import { BREAKPOINTS } from '@/src/constants/styles';
 
 export const StyledCollaboratorSmallCardContainer = styled.div<{
   $pointer?: boolean;
@@ -14,17 +15,21 @@ export const StyledCollaboratorSmallCardContainer = styled.div<{
   }
 `;
 
-export const StyledCollaboratorSmallCardPictureContainerStyled = styled.div<{
-  $isMobile: boolean;
-}>`
-  min-width: ${(props) => (props.$isMobile ? ' 50px' : '80px')};
-  width: ${(props) => (props.$isMobile ? ' 50px' : '80px')};
-  height: ${(props) => (props.$isMobile ? ' 50px' : '80px')};
+export const StyledCollaboratorSmallCardPictureContainerStyled = styled.div`
+  min-width: 80px;
+  width: 80px;
+  height: 80px;
   border-radius: 50%;
   overflow: hidden;
   align-items: center;
   justify-content: center;
   position: relative;
+
+  @media (max-width: ${BREAKPOINTS.desktop}px) {
+    min-width: 50px;
+    width: 50px;
+    height: 50px;
+  }
 `;
 
 export const StyledCollaboratorSmallCardInfosContainer = styled.div`

--- a/src/features/companies/CollaboratorSmallCard/CollaboratorSmallCard.tsx
+++ b/src/features/companies/CollaboratorSmallCard/CollaboratorSmallCard.tsx
@@ -43,7 +43,7 @@ export const CollaboratorSmallCard = ({
         </div>
       )}
       {!!email && (
-        <StyledCollaboratorSmallCardPictureContainerStyled $isMobile={isMobile}>
+        <StyledCollaboratorSmallCardPictureContainerStyled>
           <LegacyImg
             src="/static/img/profile-placeholder.png"
             alt="Default Profile"


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9357](https://entourage-asso.atlassian.net/browse/EN-9357)
**💬 Commentaire :**

This pull request refactors how responsive/mobile styling is handled across several UI components. Instead of passing device type or mobile/desktop flags as props or CSS classes, it now leverages CSS media queries directly within styled components for cleaner and more maintainable code. Additionally, it updates some height calculations to use `100dvh` for improved mobile viewport handling.

**Responsive Design Refactoring:**

* Removed all usage of device type props (such as `$device` or `$isMobile`) and conditional class names for mobile/desktop from components like `TextArea`, `MessagingConversation`, `MessagingEditor`, `MessagingConversationList`, and `CollaboratorSmallCard`. Responsive behavior is now handled via CSS media queries inside styled components. [[1]](diffhunk://#diff-f9bc511657bb6123c714a57a4845f83e52810378c3d6449df69b6bb4559e5c0eL3) [[2]](diffhunk://#diff-f9bc511657bb6123c714a57a4845f83e52810378c3d6449df69b6bb4559e5c0eL50) [[3]](diffhunk://#diff-f9bc511657bb6123c714a57a4845f83e52810378c3d6449df69b6bb4559e5c0eL93) [[4]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eL308-R308) [[5]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eL346-R343) [[6]](diffhunk://#diff-097e8836c2bf4943e8f6700cd50f5fd2f93c77fdf472948ec1a3bdd4ed42a82eL358-R355) [[7]](diffhunk://#diff-21426c1e8196e1de55a9b5593b25bb8e6fd8e98bf6dbcf127a179f7ba92752aaL136-R136) [[8]](diffhunk://#diff-aef51f9df69420396dbf8d3bc9608529abf0de892172dd6ae61372ad380166aaL96-R96) [[9]](diffhunk://#diff-0ebc32df2af6f705bbe1944cba06499df73ac0ffc53d5c8f2fb4cfaf236a68e4L17-R32) [[10]](diffhunk://#diff-a2df6be5bb4f2868a935ef3eda884db8e655b1dd16792f4e1e720eb5f101e4bcL46-R46)

* Updated styled components to use `@media (max-width: ${BREAKPOINTS.desktop}px)` for mobile-specific styles, replacing previous class-based approaches. This affects components in messaging and collaborator card features. [[1]](diffhunk://#diff-ff7e0fedb757e992b0fb5038ba7bc089ddb26d1139c8f8c2da683176f610258fL2-R2) [[2]](diffhunk://#diff-ff7e0fedb757e992b0fb5038ba7bc089ddb26d1139c8f8c2da683176f610258fR23-R26) [[3]](diffhunk://#diff-1c2fe56eb426f30d80bdcb34b06492e2261b51015038463e90579036498d0e0eL2-R2) [[4]](diffhunk://#diff-1c2fe56eb426f30d80bdcb34b06492e2261b51015038463e90579036498d0e0eL11-R11) [[5]](diffhunk://#diff-1c2fe56eb426f30d80bdcb34b06492e2261b51015038463e90579036498d0e0eL31-R31) [[6]](diffhunk://#diff-7f34411d50f0245a36c4602ba8e6607e70fc2902f1e8b31fbbbd72cd451a35a2L2-R2) [[7]](diffhunk://#diff-7f34411d50f0245a36c4602ba8e6607e70fc2902f1e8b31fbbbd72cd451a35a2L24-R26) [[8]](diffhunk://#diff-0ebc32df2af6f705bbe1944cba06499df73ac0ffc53d5c8f2fb4cfaf236a68e4R2)

**Mobile Viewport Improvements:**

* Changed height calculations from `100vh` to `100dvh` in multiple messaging-related containers to ensure correct sizing on mobile browsers that use dynamic viewports. [[1]](diffhunk://#diff-12e59757cac1611a93b6c811a047c6244d5dda04ea00e1a43164ad52d56c8aacR11) [[2]](diffhunk://#diff-12e59757cac1611a93b6c811a047c6244d5dda04ea00e1a43164ad52d56c8aacR25) [[3]](diffhunk://#diff-12e59757cac1611a93b6c811a047c6244d5dda04ea00e1a43164ad52d56c8aacR57)

**Code Cleanup:**

* Removed the now-unnecessary `useIsMobile` hook import and related logic from affected components. [[1]](diffhunk://#diff-f9bc511657bb6123c714a57a4845f83e52810378c3d6449df69b6bb4559e5c0eL3) [[2]](diffhunk://#diff-f9bc511657bb6123c714a57a4845f83e52810378c3d6449df69b6bb4559e5c0eL50)

These changes make the codebase more robust, easier to maintain, and ensure a more consistent responsive experience across devices.

[EN-9357]: https://entourage-asso.atlassian.net/browse/EN-9357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ