### PR TITLE
Add available mirror role participant count in profile

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -284,6 +284,7 @@ export type UserStats = {
   averageDelayResponse: number | null;
   responseRate: number | null;
   totalConversationWithMirrorRoleCount: number | null;
+  availableMirrorRoleParticipantsCount: number | null;
 };
 
 export enum FeatureKey {

--- a/src/features/backoffice/parameters/Parameters.tsx
+++ b/src/features/backoffice/parameters/Parameters.tsx
@@ -123,6 +123,9 @@ export const Parameters = () => {
         totalConversationWithMirrorRoleCount={
           userStats?.totalConversationWithMirrorRoleCount ?? null
         }
+        availableMirrorRoleParticipantsCount={
+          userStats?.availableMirrorRoleParticipantsCount ?? null
+        }
         lastConnection={user.lastConnection ?? null}
         achievements={achievements ?? []}
       />

--- a/src/features/backoffice/profile/Profile.tsx
+++ b/src/features/backoffice/profile/Profile.tsx
@@ -58,6 +58,9 @@ export const Profile = () => {
         totalConversationWithMirrorRoleCount={
           selectedProfile.totalConversationWithMirrorRoleCount ?? null
         }
+        availableMirrorRoleParticipantsCount={
+          selectedProfile.availableMirrorRoleParticipantsCount ?? null
+        }
         lastConnection={selectedProfile.lastConnection ?? null}
         achievements={selectedProfile.achievements ?? []}
         gender={selectedProfile.gender}

--- a/src/features/headers/HeaderProfile/HeaderProfile.desktop.tsx
+++ b/src/features/headers/HeaderProfile/HeaderProfile.desktop.tsx
@@ -62,6 +62,7 @@ export const HeaderProfileDesktop = ({
   averageDelayResponse,
   responseRate,
   totalConversationWithMirrorRoleCount,
+  availableMirrorRoleParticipantsCount,
   lastConnection,
   achievements,
 }: HeaderProfileProps) => {
@@ -173,6 +174,9 @@ export const HeaderProfileDesktop = ({
                         totalConversationWithMirrorRoleCount={
                           totalConversationWithMirrorRoleCount ?? null
                         }
+                        availableMirrorRoleParticipantsCount={
+                          availableMirrorRoleParticipantsCount ?? null
+                        }
                         lastConnection={lastConnection}
                         isOwnProfile={ownProfile}
                       />
@@ -202,6 +206,9 @@ export const HeaderProfileDesktop = ({
                   responseRate={responseRate ?? null}
                   totalConversationWithMirrorRoleCount={
                     totalConversationWithMirrorRoleCount ?? null
+                  }
+                  availableMirrorRoleParticipantsCount={
+                    availableMirrorRoleParticipantsCount ?? null
                   }
                   lastConnection={lastConnection}
                   isOwnProfile={ownProfile}

--- a/src/features/headers/HeaderProfile/HeaderProfile.mobile.tsx
+++ b/src/features/headers/HeaderProfile/HeaderProfile.mobile.tsx
@@ -65,6 +65,7 @@ export const HeaderProfileMobile = ({
   averageDelayResponse,
   responseRate,
   totalConversationWithMirrorRoleCount,
+  availableMirrorRoleParticipantsCount,
   lastConnection,
   achievements,
 }: HeaderProfileProps) => {
@@ -181,6 +182,9 @@ export const HeaderProfileMobile = ({
             responseRate={responseRate || null}
             totalConversationWithMirrorRoleCount={
               totalConversationWithMirrorRoleCount || null
+            }
+            availableMirrorRoleParticipantsCount={
+              availableMirrorRoleParticipantsCount || null
             }
             lastConnection={lastConnection}
             isOwnProfile={ownProfile}

--- a/src/features/headers/HeaderProfile/HeaderProfile.types.ts
+++ b/src/features/headers/HeaderProfile/HeaderProfile.types.ts
@@ -20,6 +20,7 @@ export interface HeaderProfileProps {
   averageDelayResponse: number | null;
   responseRate: number | null;
   totalConversationWithMirrorRoleCount: number | null;
+  availableMirrorRoleParticipantsCount: number | null;
   lastConnection: string;
 
   // Only for own profile

--- a/src/features/profile/ProfilePartCards/ProfileStats/ProfileStats.tsx
+++ b/src/features/profile/ProfilePartCards/ProfileStats/ProfileStats.tsx
@@ -15,6 +15,7 @@ interface ProfileStatsProps {
   lastConnection: string;
   responseRate: number | null;
   totalConversationWithMirrorRoleCount: number | null;
+  availableMirrorRoleParticipantsCount: number | null;
   isOwnProfile: boolean;
 }
 
@@ -30,6 +31,7 @@ export const ProfileStats = ({
   lastConnection,
   responseRate,
   totalConversationWithMirrorRoleCount,
+  availableMirrorRoleParticipantsCount,
   isOwnProfile,
 }: ProfileStatsProps) => {
   const relativeConnectionDateInDays = useMemo(() => {
@@ -100,6 +102,18 @@ export const ProfileStats = ({
         });
       }
     }
+    if (
+      availableMirrorRoleParticipantsCount &&
+      availableMirrorRoleParticipantsCount > 0 &&
+      userRole === UserRoles.CANDIDATE
+    ) {
+      list.push({
+        value: `${availableMirrorRoleParticipantsCount} coach${
+          availableMirrorRoleParticipantsCount > 1 ? 's' : ''
+        } à ses côtés`,
+        icon: <LucidIcon name="HandHeart" />,
+      });
+    }
     return list;
   }, [
     createdAt,
@@ -108,6 +122,7 @@ export const ProfileStats = ({
     responseRate,
     averageDelayResponse,
     totalConversationWithMirrorRoleCount,
+    availableMirrorRoleParticipantsCount,
     userRole,
   ]);
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9378](https://entourage-asso.atlassian.net/browse/EN-9378)
**🚧 PR-Back :** [back/516](https://github.com/ReseauEntourage/entourage-job-back/pull/516)
**💬 Commentaire :**

This pull request adds support for displaying the number of available mirror role participants (e.g., coaches) in various user profile and stats components. The main changes involve updating type definitions, component props, and rendering logic to include the new `availableMirrorRoleParticipantsCount` field, and ensuring it is shown in the UI for candidates when available.

**Type and Prop Updates**

* Added `availableMirrorRoleParticipantsCount` to the `UserStats` type in `src/api/types.ts`, and to the relevant props interfaces for profile and header components (`HeaderProfileProps`, `ProfileStatsProps`). [[1]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR287) [[2]](diffhunk://#diff-4051fa1d00a1c194960fda70bb6a062387b7c73d75a90438e87a86be0faa1f3cR23) [[3]](diffhunk://#diff-ef3e0eb18d15945195290160af553398a51a54d3fa7283fbd0d5d81e2f9a7f75R18)

**Component Prop Wiring**

* Passed `availableMirrorRoleParticipantsCount` through the `Parameters`, `Profile`, `HeaderProfileDesktop`, and `HeaderProfileMobile` components, ensuring the value is available where needed in the UI. [[1]](diffhunk://#diff-951b9a9bb06400c7944b7917fd5affce83fdd9942bb91b34f798e6eb63c4ba75R126-R128) [[2]](diffhunk://#diff-7bc75903512ace1e499a0dfc4c7e90d340d9cf201a51d2ab529891469955729fR61-R63) [[3]](diffhunk://#diff-2996284946b900112820a1001c414656fd12a9a33d1123304cd4f9269a441309R65) [[4]](diffhunk://#diff-2996284946b900112820a1001c414656fd12a9a33d1123304cd4f9269a441309R177-R179) [[5]](diffhunk://#diff-2996284946b900112820a1001c414656fd12a9a33d1123304cd4f9269a441309R210-R212) [[6]](diffhunk://#diff-f59517f82e8d3a832d1954c76949201c5a3b526608e8c04d14f49c25ce955cd8R68) [[7]](diffhunk://#diff-f59517f82e8d3a832d1954c76949201c5a3b526608e8c04d14f49c25ce955cd8R186-R188) [[8]](diffhunk://#diff-ef3e0eb18d15945195290160af553398a51a54d3fa7283fbd0d5d81e2f9a7f75R34) [[9]](diffhunk://#diff-ef3e0eb18d15945195290160af553398a51a54d3fa7283fbd0d5d81e2f9a7f75R125)

**UI Logic and Display**

* Updated `ProfileStats` to conditionally display the number of available coaches for candidates, including pluralization and an icon, when the count is greater than zero.

These changes collectively ensure that the UI now reflects the number of available mirror role participants for users, improving information visibility for candidates.

[EN-9378]: https://entourage-asso.atlassian.net/browse/EN-9378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ