### PR TITLE
Add autologin management via token in URL for new message notifications

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -19,6 +19,7 @@ import {
   InviteCollaboratorsFromCompanyDto,
   Organization,
   OrganizationDto,
+  PostAuthAutologinParams,
   PostAuthFinalizeReferedUserParams,
   PostAuthSendVerifyEmailParams,
   PostAuthVerifyOtpParams,
@@ -605,6 +606,12 @@ export class APIHandler {
     params: PostAuthFinalizeReferedUserParams
   ): Promise<AxiosResponse<string>> {
     return this.post('/auth/finalize-refered-user', params);
+  }
+
+  postAuthAutologin(
+    params: PostAuthAutologinParams
+  ): Promise<AxiosResponse<{ token: string }>> {
+    return this.post('/auth/autologin', params);
   }
 
   // no logout?

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -765,6 +765,10 @@ export type PostAuthFinalizeReferedUserParams = {
   password: string;
 };
 
+export type PostAuthAutologinParams = {
+  token: string;
+};
+
 export type ExternalCv = {
   url: string;
 };

--- a/src/hooks/authentication/useAuthentication.spec.tsx
+++ b/src/hooks/authentication/useAuthentication.spec.tsx
@@ -1,0 +1,174 @@
+jest.mock('@/src/api');
+
+jest.mock('next/router', () => ({ useRouter: jest.fn() }));
+
+// The permissions logic itself isn't the concern of this test — always allow
+// the route so the autologin interception can be observed in isolation.
+jest.mock('./useRoutePermissions', () => ({
+  useRoutePermissions: () => ({ isUserAuthorized: true }),
+}));
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+// eslint-disable-next-line import-x/no-named-as-default
+import expect from 'expect';
+import { useRouter } from 'next/router';
+import React from 'react';
+import { Provider } from 'react-redux';
+import { STORAGE_KEYS } from '@/src/constants';
+import { createTestStore } from '@/src/store/testUtils/createTestStore';
+import { flushPromises } from '@/src/store/testUtils/flushPromises';
+import { getMockedApi } from '@/src/store/testUtils/mockApi';
+import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
+import { useAuthentication } from './useAuthentication';
+
+const mockedApi = getMockedApi();
+const mockUseRouter = useRouter as jest.Mock;
+
+function renderWithStore(store: ReturnType<typeof createTestStore>) {
+  return renderHook(() => useAuthentication(), {
+    wrapper: ({ children }) => <Provider store={store}>{children}</Provider>,
+  });
+}
+
+// Lets every pending microtask (mutation dispatch -> listener middleware ->
+// RTK Query -> reducer -> re-render) settle inside `act`, so a still-pending
+// update from one test can't bleed into the next test's render assertions.
+async function settle() {
+  await act(async () => {
+    await flushPromises();
+  });
+}
+
+describe('useAuthentication - autologin interception', () => {
+  const replace = jest.fn();
+  const push = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockedApi.getCurrentIdentity.mockResolvedValue({
+      data: { id: 'user-1', onboardingStatus: 'STARTED' },
+    } as any);
+  });
+
+  // Each hook keeps its own effects/subscriptions running otherwise, and a
+  // still-mounted previous test's `replace`/`push` calls (shared jest.fn
+  // instances) would bleed into the next test's assertions.
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('exchanges the autologin token for a session and strips it from the URL, without an eager unauthenticated fetch', async () => {
+    mockUseRouter.mockReturnValue({
+      replace,
+      push,
+      asPath: '/backoffice/messaging?userId=author&autologinToken=abc.def',
+      query: { userId: 'author', autologinToken: 'abc.def' },
+      isReady: true,
+      pathname: '/backoffice/messaging',
+    });
+    mockedApi.postAuthAutologin.mockResolvedValue({
+      data: { token: 'session-token' },
+    } as any);
+
+    const store = createTestStore();
+    const { unmount } = renderWithStore(store);
+
+    // The autologin exchange starts immediately, but the classic
+    // unauthenticated fetchUser call must not fire while it's pending.
+    expect(mockedApi.postAuthAutologin).toHaveBeenCalledWith({
+      token: 'abc.def',
+    });
+    expect(mockedApi.getCurrentIdentity).not.toHaveBeenCalled();
+
+    await settle();
+
+    expect(store.getState().authentication.accessToken).toBe('session-token');
+    expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBe(
+      'session-token'
+    );
+    expect(replace).toHaveBeenCalledWith(
+      { pathname: '/backoffice/messaging', query: { userId: 'author' } },
+      undefined,
+      { shallow: true }
+    );
+
+    // Once the exchange is resolved, the guarded fetchUser effect is free to
+    // run and picks up the freshly stored token.
+    await settle();
+    expect(mockedApi.getCurrentIdentity).toHaveBeenCalledTimes(1);
+
+    // Let the chained fetchUser mutation itself fully resolve before
+    // unmounting, so no listener effect from this test's store is still
+    // in-flight when the next test starts (the listener middleware is a
+    // singleton shared across every `createTestStore()` instance).
+    await settle();
+    unmount();
+    await settle();
+  });
+
+  it('falls back to the normal unauthenticated flow when the token is invalid/expired/already used', async () => {
+    mockUseRouter.mockReturnValue({
+      replace,
+      push,
+      asPath: '/backoffice/messaging?userId=author&autologinToken=bad.token',
+      query: { userId: 'author', autologinToken: 'bad.token' },
+      isReady: true,
+      pathname: '/backoffice/messaging',
+    });
+    mockedApi.postAuthAutologin.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 401, data: { message: 'AUTOLOGIN_TOKEN_INVALID' } },
+    });
+
+    const store = createTestStore();
+    const { unmount, rerender } = renderWithStore(store);
+
+    await settle();
+    await settle();
+    // A render nudge: the mutation's rejection is fully reflected in the
+    // store by this point (asserted below), but in this test file's
+    // multi-store sequence React doesn't always re-run on its own — force
+    // one so the URL-cleanup effect gets to observe the settled FAILED
+    // status.
+    rerender();
+    await settle();
+
+    expect(store.getState().authentication.accessToken).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBeNull();
+    expect(replace).toHaveBeenCalledWith(
+      { pathname: '/backoffice/messaging', query: { userId: 'author' } },
+      undefined,
+      { shallow: true }
+    );
+
+    unmount();
+    await settle();
+  });
+
+  it('does not attempt an exchange when there is no autologin token in the URL', async () => {
+    mockUseRouter.mockReturnValue({
+      replace,
+      push,
+      asPath: '/backoffice/messaging?userId=author',
+      query: { userId: 'author' },
+      isReady: true,
+      pathname: '/backoffice/messaging',
+    });
+    // `fetchUser`'s queryFn short-circuits to NOT_AUTHENTICATED without
+    // calling the API when there's no access token — seed one so the
+    // ordinary (non-autologin) idle-triggered fetch actually reaches it.
+    seedAccessToken('already-logged-in-token');
+
+    const store = createTestStore();
+    const { unmount } = renderWithStore(store);
+    await settle();
+    await settle();
+
+    expect(mockedApi.postAuthAutologin).not.toHaveBeenCalled();
+    expect(mockedApi.getCurrentIdentity).toHaveBeenCalledTimes(1);
+
+    unmount();
+    await settle();
+  });
+});

--- a/src/hooks/authentication/useAuthentication.ts
+++ b/src/hooks/authentication/useAuthentication.ts
@@ -1,8 +1,10 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { ReduxRequestEvents } from '@/src/constants';
 import {
   authenticationActions,
+  autologinSelectors,
   logoutSelectors,
 } from '@/src/use-cases/authentication';
 
@@ -16,7 +18,7 @@ import { getDefaultUrl } from '@/src/utils/Redirects';
 import { useRoutePermissions } from './useRoutePermissions';
 
 export function useAuthentication() {
-  const { replace, asPath, push } = useRouter();
+  const { replace, asPath, push, query, isReady, pathname } = useRouter();
   const dispatch = useDispatch();
 
   const isFetchUserSucceeded = useSelector(
@@ -30,14 +32,55 @@ export function useAuthentication() {
   );
   const isFetchUserIdle = useSelector(fetchUserSelectors.selectIsFetchUserIdle);
   const currentUser = useSelector(selectCurrentUser);
-  const isAuthenticationPending = !isFetchUserSucceeded && !isFetchUserFailed;
   const { isUserAuthorized } = useRoutePermissions();
   const isUserAuthenticated = !!currentUser;
   const currentUserRole = currentUser?.role;
 
+  // Interception du lien de notification de nouveau message : échange le
+  // token d'autologin présent en query param contre une session, avant que
+  // les effets ci-dessous ne déclenchent le fetch utilisateur classique ou
+  // la redirection vers /login.
+  const autologinToken =
+    typeof query.autologinToken === 'string' ? query.autologinToken : null;
+  const autologinStatus = useSelector(autologinSelectors.selectAutologinStatus);
+  const isAutologinPending =
+    isReady &&
+    !!autologinToken &&
+    autologinStatus !== ReduxRequestEvents.SUCCEEDED &&
+    autologinStatus !== ReduxRequestEvents.FAILED;
+
+  useEffect(() => {
+    if (
+      isReady &&
+      autologinToken &&
+      autologinStatus === ReduxRequestEvents.IDLE
+    ) {
+      dispatch(
+        authenticationActions.autologinRequested({ token: autologinToken })
+      );
+    }
+  }, [dispatch, isReady, autologinToken, autologinStatus]);
+
+  // Une fois l'échange terminé (succès ou échec), retire le paramètre de
+  // l'URL sans changer de destination, pour éviter qu'un rafraîchissement ne
+  // retente un échange déjà consommé.
+  useEffect(() => {
+    if (
+      autologinToken &&
+      (autologinStatus === ReduxRequestEvents.SUCCEEDED ||
+        autologinStatus === ReduxRequestEvents.FAILED)
+    ) {
+      const { autologinToken: _removed, ...restQuery } = query;
+      replace({ pathname, query: restQuery }, undefined, { shallow: true });
+    }
+  }, [autologinToken, autologinStatus, pathname, query, replace]);
+
+  const isAuthenticationPending =
+    isAutologinPending || (!isFetchUserSucceeded && !isFetchUserFailed);
+
   // Trigger fetching user data if idle
   useEffect(() => {
-    if (isFetchUserIdle) {
+    if (isFetchUserIdle && !isAutologinPending) {
       dispatch(currentUserActions.fetchUserRequested());
     }
   }, [
@@ -45,6 +88,7 @@ export function useAuthentication() {
     isFetchUserIdle,
     isFetchUserSucceeded,
     isFetchUserFailed,
+    isAutologinPending,
     currentUser,
   ]);
 

--- a/src/use-cases/authentication/authentication.api.spec.ts
+++ b/src/use-cases/authentication/authentication.api.spec.ts
@@ -10,6 +10,7 @@ import { seedAccessToken } from '@/src/store/testUtils/seedAccessToken';
 import { selectFetchCurrentProfileStatus } from '@/src/use-cases/current-user';
 import { VerifyEmailTokenErrorType } from './authentication.adapters';
 import {
+  autologinSelectors,
   logoutSelectors,
   sendVerifyEmailSelectors,
   verifyEmailTokenSelectors,
@@ -294,6 +295,47 @@ describe('authentication api', () => {
       await flushPromises();
 
       expect(store.getState().authentication.verifyOtpError).toBe('INVALID');
+    });
+  });
+
+  describe('autologinRequested (trigger listener)', () => {
+    it('logs in and stores the access token on success', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthAutologin.mockResolvedValue({
+        data: { token: 'autologin-token' },
+      } as any);
+
+      store.dispatch(actions.autologinRequested({ token: 'link-token' }));
+      await flushPromises();
+
+      expect(store.getState().authentication.accessToken).toBe(
+        'autologin-token'
+      );
+      expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBe(
+        'autologin-token'
+      );
+      expect(autologinSelectors.selectAutologinStatus(store.getState())).toBe(
+        'SUCCEEDED'
+      );
+      expect(mockedApi.postAuthAutologin).toHaveBeenCalledWith({
+        token: 'link-token',
+      });
+    });
+
+    it('fails without touching the access token when the token is invalid/expired/already used', async () => {
+      const store = createTestStore();
+      mockedApi.postAuthAutologin.mockRejectedValue(
+        buildAxiosError(401, 'AUTOLOGIN_TOKEN_EXPIRED')
+      );
+
+      store.dispatch(actions.autologinRequested({ token: 'link-token' }));
+      await flushPromises();
+
+      expect(autologinSelectors.selectAutologinStatus(store.getState())).toBe(
+        'FAILED'
+      );
+      expect(store.getState().authentication.accessToken).toBeNull();
+      expect(localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)).toBeNull();
     });
   });
 });

--- a/src/use-cases/authentication/authentication.api.ts
+++ b/src/use-cases/authentication/authentication.api.ts
@@ -37,6 +37,7 @@ export const LOGOUT_FIXED_CACHE_KEY = 'logout';
 export const VERIFY_EMAIL_TOKEN_FIXED_CACHE_KEY = 'verifyEmailToken';
 export const SEND_VERIFY_EMAIL_FIXED_CACHE_KEY = 'sendVerifyEmail';
 export const VERIFY_OTP_FIXED_CACHE_KEY = 'verifyOtp';
+export const AUTOLOGIN_FIXED_CACHE_KEY = 'autologin';
 
 export const authenticationApi = api.injectEndpoints({
   endpoints: (builder) => ({
@@ -165,6 +166,32 @@ export const authenticationApi = api.injectEndpoints({
         }
       },
     }),
+    /**
+     * Exchanges the one-time autologin token from a new message notification
+     * email link for a session. Strictly scoped to that link — on failure
+     * (invalid/expired/already consumed token), the caller falls back to the
+     * normal `/login` redirect, so no dedicated error state is tracked here.
+     */
+    autologin: builder.mutation<{ accessToken: string }, { token: string }>({
+      queryFn: async ({ token }) => {
+        try {
+          const response = await Api.postAuthAutologin({ token });
+          return { data: { accessToken: response.data.token } };
+        } catch (error) {
+          return { error };
+        }
+      },
+      onQueryStarted: async (_arg, { dispatch, queryFulfilled }) => {
+        try {
+          const { data } = await queryFulfilled;
+          dispatch(loginSucceeded(data));
+          localStorage.setItem(STORAGE_KEYS.ACCESS_TOKEN, data.accessToken);
+        } catch {
+          // No dedicated failure state: the caller falls back to the
+          // normal unauthenticated flow (redirect to `/login`).
+        }
+      },
+    }),
   }),
 });
 
@@ -174,4 +201,5 @@ export const {
   useVerifyEmailTokenMutation,
   useSendVerifyEmailMutation,
   useVerifyOtpMutation,
+  useAutologinMutation,
 } = authenticationApi;

--- a/src/use-cases/authentication/authentication.listeners.ts
+++ b/src/use-cases/authentication/authentication.listeners.ts
@@ -1,5 +1,6 @@
 import { listenerMiddleware } from '@/src/store/listenerMiddleware';
 import {
+  AUTOLOGIN_FIXED_CACHE_KEY,
   authenticationApi,
   LOGIN_FIXED_CACHE_KEY,
   LOGOUT_FIXED_CACHE_KEY,
@@ -66,6 +67,17 @@ listenerMiddleware.startListening({
     listenerApi.dispatch(
       authenticationApi.endpoints.verifyOtp.initiate(action.payload, {
         fixedCacheKey: VERIFY_OTP_FIXED_CACHE_KEY,
+      })
+    );
+  },
+});
+
+listenerMiddleware.startListening({
+  actionCreator: actions.autologinRequested,
+  effect: (action, listenerApi) => {
+    listenerApi.dispatch(
+      authenticationApi.endpoints.autologin.initiate(action.payload, {
+        fixedCacheKey: AUTOLOGIN_FIXED_CACHE_KEY,
       })
     );
   },

--- a/src/use-cases/authentication/authentication.selectors.ts
+++ b/src/use-cases/authentication/authentication.selectors.ts
@@ -1,6 +1,7 @@
 import { ReduxRequestEvents } from '@/src/constants';
 import { api } from '@/src/store/api/api.slice';
 import {
+  AUTOLOGIN_FIXED_CACHE_KEY,
   authenticationApi,
   SEND_VERIFY_EMAIL_FIXED_CACHE_KEY,
   VERIFY_EMAIL_TOKEN_FIXED_CACHE_KEY,
@@ -92,3 +93,12 @@ export const verifyOtpSelectors = {
 export function selectVerifyOtpError(state: RootState) {
   return state.authentication.verifyOtpError;
 }
+
+export const autologinSelectors = {
+  selectAutologinStatus: (state: RootState) =>
+    toReduxRequestStatus(
+      authenticationApi.endpoints.autologin.select(AUTOLOGIN_FIXED_CACHE_KEY)(
+        state
+      )
+    ),
+};

--- a/src/use-cases/authentication/authentication.slice.ts
+++ b/src/use-cases/authentication/authentication.slice.ts
@@ -89,6 +89,7 @@ export const slice = createSlice({
       _state,
       _action: PayloadAction<{ email: string; code: string }>
     ) {},
+    autologinRequested(_state, _action: PayloadAction<{ token: string }>) {},
   },
 });
 


### PR DESCRIPTION
**🗒️ Ticket Jira :** [EN-9385](https://entourage-asso.atlassian.net/browse/EN-9385)
**🚧 PR-Back :** [back/518](https://github.com/ReseauEntourage/entourage-job-back/pull/518)
**💬 Commentaire :**

This pull request implements support for autologin via one-time tokens, allowing users to log in automatically when accessing the application through special links (e.g., from email notifications). The main changes include backend API integration for autologin, Redux state and listeners to handle the autologin flow, and comprehensive tests to ensure correct behavior for various scenarios.

**Autologin feature implementation:**

* Added `postAuthAutologin` API method and corresponding `PostAuthAutologinParams` type to `src/api/api.ts` and `src/api/types.ts` for exchanging autologin tokens for session tokens. [[1]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542R22) [[2]](diffhunk://#diff-ba54f2f51eac8ba66d9ea37ae9d3c13bbd71cf8c54d9cd898318e6267b0e6542R611-R616) [[3]](diffhunk://#diff-68572da928b5651e3f8dda9d2b291815dc0cdf0e0ff5dc40ab3dc81215b760feR768-R771)
* Introduced the `autologin` mutation endpoint in `authenticationApi` with proper cache key handling (`AUTOLOGIN_FIXED_CACHE_KEY`) and token storage on success. [[1]](diffhunk://#diff-b60ad733a3d4ec413d29579d4a00978b7ce4af05a534f2cb48f9f0c9e12398c9R40) [[2]](diffhunk://#diff-b60ad733a3d4ec413d29579d4a00978b7ce4af05a534f2cb48f9f0c9e12398c9R169-R194) [[3]](diffhunk://#diff-b60ad733a3d4ec413d29579d4a00978b7ce4af05a534f2cb48f9f0c9e12398c9R204)

**Redux integration and listeners:**

* Added `autologinRequested` action and listener to trigger the autologin mutation when an autologin token is detected, and selectors to track autologin status. [[1]](diffhunk://#diff-02828137a85594c8c2ee6544ef91ba782fe27601524303261020c70efe224e40R92) [[2]](diffhunk://#diff-3438f00330efe3b017718442feb03ce7c611c1cb58e27fa334db11c29656d533R3) [[3]](diffhunk://#diff-3438f00330efe3b017718442feb03ce7c611c1cb58e27fa334db11c29656d533R74-R84) [[4]](diffhunk://#diff-ebdaa122250339ad371bf27a35b79b7381e0fd270b8cfcc1584cb4f4fc831a91R4) [[5]](diffhunk://#diff-ebdaa122250339ad371bf27a35b79b7381e0fd270b8cfcc1584cb4f4fc831a91R96-R104) [[6]](diffhunk://#diff-583deea92873676611a422878824c004e9fdacb69ba4713c23fd51cdc50609feR13)

**Hook and flow updates:**

* Updated `useAuthentication` to intercept autologin tokens from the URL, initiate the autologin flow, and clean up the URL after the exchange (success or failure), ensuring the normal authentication flow is only triggered if autologin is not pending. [[1]](diffhunk://#diff-4fe1d8329daea294a7d33f20ece2ba4701737f611ed5a565b1e1931eb43d274fR4-R7) [[2]](diffhunk://#diff-4fe1d8329daea294a7d33f20ece2ba4701737f611ed5a565b1e1931eb43d274fL19-R21) [[3]](diffhunk://#diff-4fe1d8329daea294a7d33f20ece2ba4701737f611ed5a565b1e1931eb43d274fL33-R91)

**Testing improvements:**

* Added comprehensive tests for the autologin flow, covering successful token exchange, failure scenarios (invalid/expired tokens), and ensuring the normal authentication flow is not disrupted. [[1]](diffhunk://#diff-a8790362a7c8c2020098b7cd5fdfa588e2f74f661d72f75509939a0d37edc096R1-R174) [[2]](diffhunk://#diff-583deea92873676611a422878824c004e9fdacb69ba4713c23fd51cdc50609feR300-R340)

[EN-9385]: https://entourage-asso.atlassian.net/browse/EN-9385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ